### PR TITLE
Mention Checkstyle Addons in the list of 'notable extensions'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ If an error occurs during the check an exception will be thrown, which IDEA will
 *sevntu.checkstyle* offers a number of useful checks written by students of the Sevastopol National Technical University (SevNTU). They're also kind enough to
 offer instructions on setting them up with this plugin.
 
+### [Checkstyle Addons](http://checkstyle-addons.thomasjensen.com/)
+
+*Checkstyle Addons* offers additional Checkstyle checks not found in other Checkstyle extensions, and it's easy to [set up in Checkstyle-IDEA](http://checkstyle-addons.thomasjensen.com/run.html#run-intellij).
+
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
I am the author of [Checkstyle Addons](https://github.com/checkstyle-addons/checkstyle-addons), a small collection of additional Checkstyle checks. Checkstyle Addons is designed to work with Checkstyle-IDEA ([setup instructions](http://checkstyle-addons.thomasjensen.com/run.html#run-intellij)).
I would like to ask you to add a link to Checkstyle Addons to the README.md list of extensions.
Checkstyle Addons is free and open source. - Thank you!