### PR TITLE
Updated to CheckStyle 6.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ This code is released under a BSD licence, as specified in the accompanying LICE
 
 ## Version History
 
+* **4.21.0** New: Updated to CheckStyle 6.12.1.
 * **4.20.1** Fixed: Inspection now checks for cancellation (#192).
 * **4.20.1** Fixed: Rules accessed via HTTP no longer use temporary files (#67).
 * **4.20.0** New: Updated to CheckStyle 6.11.2 (#189).

--- a/bin/get-checkstyle-artefact
+++ b/bin/get-checkstyle-artefact
@@ -5,6 +5,6 @@
 #
 # (This seems fixed in 14.1, but :paranoia:)
 
-CHECKSTYLE_VERSION=6.11.2
+CHECKSTYLE_VERSION=6.12.1
 
 mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get -DrepoUrl=http://http://repo2.maven.org/maven2/com/puppycrawl/tools/ -Dartifact=com.puppycrawl.tools:checkstyle:$CHECKSTYLE_VERSION

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 sourceCompatibility = 1.8
-version = '4.20.1'
+version = '4.21.0'
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.7'
@@ -18,7 +18,7 @@ configurations {
 dependencies {
     ideaSdkLibs fileTree(dir: "$ideaSdk", include: '*.jar')
 
-    compile(group: 'com.puppycrawl.tools', name: 'checkstyle', version: '6.11.2') {
+    compile(group: 'com.puppycrawl.tools', name: 'checkstyle', version: '6.12.1') {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     compile group: 'commons-io', name: 'commons-io', version: '2.4'

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,11 +6,11 @@
         <![CDATA[
 <p>
     This plugin provides both real-time and on-demand scanning
-    of Java files with CheckStyle 6.11.2 from within IDEA.
+    of Java files with CheckStyle 6.12.1 from within IDEA.
 </p>
         ]]>
     </description>
-    <version>4.20.1</version>
+    <version>4.21.0</version>
     <idea-version since-build="141.178"/>
     <vendor url="http://infernus.org/" email="james@infernus.org">James Shiell</vendor>
 
@@ -19,6 +19,7 @@
     <change-notes>
         <![CDATA[
 <ul>
+    <li>4.21.0: New: Updated to CheckStyle 6.12.1.</li>
     <li>4.20.1: Fixed: Inspection now checks for cancellation (#192).</li>
     <li>4.20.1: Fixed: Rules accessed via HTTP no longer use temporary files (#67).</li>
     <li>4.20.0: New: Updated to CheckStyle 6.11.2 (#189).</li>


### PR DESCRIPTION
Hi - could we upgrade to Checkstyle 6.12.1?
SonarQube have just released their [Checkstyle plugin](http://docs.sonarqube.org/display/PLUG/Checkstyle+Plugin) for 6.12.1. That is a rare occurrence, and it would be really nice to have an IDEA plugin to match. :smile:
Here's a PR to help save you some work.

Thanks!