### PR TITLE
Checkstyle code style importer: initial implementation

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/importer/CheckStyleCodeStyleImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/CheckStyleCodeStyleImporter.java
@@ -1,0 +1,79 @@
+package org.infernus.idea.checkstyle.importer;
+
+import com.intellij.openapi.options.SchemeFactory;
+import com.intellij.openapi.options.SchemeImportException;
+import com.intellij.openapi.options.SchemeImporter;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.codeStyle.CodeStyleScheme;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.xml.sax.InputSource;
+
+import java.io.InputStream;
+
+/**
+ * Imports code style settings from check style configuration file.
+ */
+public class CheckStyleCodeStyleImporter implements SchemeImporter<CodeStyleScheme> {
+    @NotNull
+    @Override
+    public String[] getSourceExtensions() {
+        return new String[]{"xml"};
+    }
+
+    @Nullable
+    @Override
+    public CodeStyleScheme importScheme(@NotNull final Project project,
+                                        @NotNull final VirtualFile selectedFile,
+                                        @NotNull final CodeStyleScheme currentScheme,
+                                        @NotNull final SchemeFactory<CodeStyleScheme> schemeFactory) throws SchemeImportException {
+        try {
+            CodeStyleScheme targetScheme = currentScheme;
+            if (currentScheme.isDefault()) {
+                targetScheme = schemeFactory.createNewScheme(currentScheme.getName());
+            }
+            Configuration configuration = loadConfiguration(selectedFile);
+            if (configuration != null) {
+                importConfiguration(configuration, targetScheme.getCodeStyleSettings());
+                return targetScheme;
+            }
+        } catch (Exception e) {
+            throw new SchemeImportException(e);
+        }
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getAdditionalImportInfo(@NotNull final CodeStyleScheme scheme) {
+        return null;
+    }
+    
+    @Nullable
+    private Configuration loadConfiguration(@NotNull VirtualFile selectedFile) throws Exception {
+        InputStream inputStream = null;
+        try {
+            inputStream = selectedFile.getInputStream();
+            InputSource inputSource = new InputSource(inputStream);
+            return ConfigurationLoader.loadConfiguration(inputSource, null, false);
+        }
+        finally {
+            if (inputStream != null) //noinspection ThrowFromFinallyBlock
+                inputStream.close();
+        }
+    }
+
+    static void importConfiguration(@NotNull Configuration configuration, @NotNull CodeStyleSettings settings) 
+            throws IllegalAccessException, InstantiationException {
+        ModuleImporter moduleImporter = 
+                ModuleImporterFactory.getModuleImporter(configuration);
+        if (moduleImporter != null) moduleImporter.importTo(settings);
+        for (Configuration childConfig : configuration.getChildren()) {
+            importConfiguration(childConfig, settings);
+        }
+    }
+}

--- a/src/main/java/org/infernus/idea/checkstyle/importer/ModuleImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/ModuleImporter.java
@@ -1,0 +1,79 @@
+package org.infernus.idea.checkstyle.importer;
+
+import com.intellij.lang.java.JavaLanguage;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class ModuleImporter {
+    private final static String TOKENS_PROP = "tokens";
+    private int[] tokens;
+
+    @NotNull
+    protected CommonCodeStyleSettings getJavaSettings(@NotNull CodeStyleSettings settings) {
+        return settings.getCommonSettings(JavaLanguage.INSTANCE); 
+    }
+    
+    public void setFrom(@NotNull Configuration moduleConfig) {
+        for (String attrName : moduleConfig.getAttributeNames()) {
+            try {
+                handleAttribute(attrName, moduleConfig.getAttribute(attrName));
+            } catch (CheckstyleException e) {
+                // Ignore, shouldn't happen
+            }
+        }
+    }
+
+    protected boolean handleAttribute(@NotNull String attrName, @NotNull String attrValue) {
+        if (TOKENS_PROP.equals(attrName)) {
+            tokens = TokenSetUtil.getTokens(attrValue);
+        }
+        return false;
+    }
+
+    protected boolean appliesTo(int tokenId) {
+        if (tokens != null) {
+            for (int token : tokens) {
+                if (token == tokenId) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+    
+    protected boolean appliesToOneOf(Set<Integer> tokenSet) {
+        if (tokens != null) {
+            for (int token : tokens) {
+                if (tokenSet.contains(token)) return true;
+            }
+            return false;
+        }
+        return true;
+    }
+    
+    protected static Set<Integer> setOf(int... ids) {
+        Set<Integer> tokenSet = new HashSet<>(ids.length);
+        for (int id : ids) {
+            tokenSet.add(id);
+        }
+        return tokenSet;
+    }
+    
+    public abstract void importTo(@NotNull CodeStyleSettings settings);
+    
+    protected int getIntOrDefault(@NotNull String intStr, int defaultValue) {
+        try {
+            return Integer.parseInt(intStr);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+}

--- a/src/main/java/org/infernus/idea/checkstyle/importer/ModuleImporterFactory.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/ModuleImporterFactory.java
@@ -1,0 +1,36 @@
+package org.infernus.idea.checkstyle.importer;
+
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+class ModuleImporterFactory {
+
+    @Nullable
+    static ModuleImporter getModuleImporter(@NotNull Configuration configuration) 
+            throws InstantiationException, IllegalAccessException {
+        String name = configuration.getName();
+        ModuleImporter moduleImporter = createImporter(name);
+        if (moduleImporter != null) {
+            moduleImporter.setFrom(configuration);
+        }
+        return moduleImporter;
+    }
+    
+    @Nullable
+    private static ModuleImporter createImporter(@NotNull String name) 
+            throws IllegalAccessException, InstantiationException {
+        String fqn = getFullyQualifiedClassName(name);
+        try {
+            Class c = Class.forName(fqn);
+            Object o = c.newInstance();
+            return o instanceof ModuleImporter ? (ModuleImporter)o : null;
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+    
+    private static String getFullyQualifiedClassName(@NotNull String moduleName) {
+        return ModuleImporterFactory.class.getPackage().getName() + ".modules." + moduleName + "Importer";
+    }
+}

--- a/src/main/java/org/infernus/idea/checkstyle/importer/TokenSetUtil.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/TokenSetUtil.java
@@ -1,0 +1,27 @@
+package org.infernus.idea.checkstyle.importer;
+
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+class TokenSetUtil {
+    private TokenSetUtil() {
+    }
+    
+    static int[] getTokens(String tokenString) {
+        String[] tokenStrings = tokenString.split("\\s*,\\s*");
+        int[] tokenIds = new int[tokenStrings.length];
+        int i = 0;
+        for (String tokenStr : tokenStrings) {
+            try {
+                Field f = TokenTypes.class.getDeclaredField(tokenStr);
+                tokenIds[i] = f.getInt(null);
+                i ++;
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                // Ignore
+            }
+        }
+        return Arrays.copyOf(tokenIds, i);
+    }
+}

--- a/src/main/java/org/infernus/idea/checkstyle/importer/modules/EmptyLineSeparatorImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/modules/EmptyLineSeparatorImporter.java
@@ -1,0 +1,44 @@
+package org.infernus.idea.checkstyle.importer.modules;
+
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import org.infernus.idea.checkstyle.importer.ModuleImporter;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public class EmptyLineSeparatorImporter extends ModuleImporter {
+    private boolean noEmptyLinesBetweenFields = false;
+    private final static String NO_EMPTY_LINES_BETWEEN_FIELDS_PROP = "allowNoEmptyLineBetweenFields";
+
+    @Override
+    protected boolean handleAttribute(@NotNull final String attrName, @NotNull final String attrValue) {
+        if (!super.handleAttribute(attrName, attrValue)) {
+            if (NO_EMPTY_LINES_BETWEEN_FIELDS_PROP.equals(attrName)) {
+                noEmptyLinesBetweenFields = Boolean.parseBoolean(attrValue);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void importTo(@NotNull final CodeStyleSettings settings) {
+        CommonCodeStyleSettings javaSettings = getJavaSettings(settings);
+        if (noEmptyLinesBetweenFields) {
+            javaSettings.BLANK_LINES_AROUND_FIELD = 0;
+        }
+        else if (appliesTo(TokenTypes.VARIABLE_DEF)) {
+            javaSettings.BLANK_LINES_AROUND_FIELD = 1;
+        }
+        if (appliesTo(TokenTypes.PACKAGE_DEF)) {
+            javaSettings.BLANK_LINES_AFTER_PACKAGE = 1;
+        }
+        if (appliesTo(TokenTypes.IMPORT)) {
+            javaSettings.BLANK_LINES_AFTER_IMPORTS = 1;
+        }
+        if (appliesTo(TokenTypes.METHOD_DEF)) {
+            javaSettings.BLANK_LINES_AROUND_METHOD = 1;
+        }
+    }
+
+}

--- a/src/main/java/org/infernus/idea/checkstyle/importer/modules/FileTabCharacterImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/modules/FileTabCharacterImporter.java
@@ -1,0 +1,47 @@
+package org.infernus.idea.checkstyle.importer.modules;
+
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.fileTypes.FileTypeManager;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import org.infernus.idea.checkstyle.importer.ModuleImporter;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public class FileTabCharacterImporter extends ModuleImporter {
+    private final static String FILE_EXTENSIONS_PROP = "fileExtensions";
+    private String[] extensions;
+    
+    @Override
+    protected boolean handleAttribute(@NotNull final String attrName, @NotNull final String attrValue) {
+        if (FILE_EXTENSIONS_PROP.equals(attrName)) {
+            extensions = attrValue.split("\\s*,\\s*");
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void importTo(@NotNull final CodeStyleSettings settings) {
+        if (extensions != null) {
+            for (String extension : extensions) {
+                if (!extension.isEmpty()) {
+                    FileType fileType = FileTypeManager.getInstance().getFileTypeByExtension(extension);
+                    setNoTabChar(settings, fileType);
+                }
+            }
+        }
+        else {
+            for (FileType fileType : FileTypeManager.getInstance().getRegisteredFileTypes()) {
+                setNoTabChar(settings, fileType);
+            }
+        }
+    }
+
+    private void setNoTabChar(final @NotNull CodeStyleSettings settings, final FileType fileType) {
+        CommonCodeStyleSettings.IndentOptions indentOptions = settings.getIndentOptions(fileType);
+        if (indentOptions != null) {
+            indentOptions.USE_TAB_CHARACTER = false;
+        }
+    }
+}

--- a/src/main/java/org/infernus/idea/checkstyle/importer/modules/IndentationImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/modules/IndentationImporter.java
@@ -1,0 +1,49 @@
+package org.infernus.idea.checkstyle.importer.modules;
+
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import org.infernus.idea.checkstyle.importer.ModuleImporter;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public class IndentationImporter extends ModuleImporter {
+    private final static String BASIC_OFFSET_PROP     = "basicOffset";
+    private final static String CASE_INDENT_PROP      = "caseIndent";
+    private final static String LINE_WRAP_INDENT_PROP = "lineWrappingIndentation";
+    
+    private final static int     DEFAULT_BASIC_OFFSET       = 4;
+    private final static int     DEFAULT_LINE_WRAP_INDENT   = 4;
+    private final static boolean DEFAULT_INDENT_CASE        = true;
+    
+    private int basicIndent = DEFAULT_BASIC_OFFSET;
+    private int continuationIndent = DEFAULT_LINE_WRAP_INDENT;
+    private boolean indentCase = DEFAULT_INDENT_CASE;
+    
+    @Override
+    protected boolean handleAttribute(@NotNull final String attrName, @NotNull final String attrValue) {
+        switch (attrName) {
+            case BASIC_OFFSET_PROP:
+                basicIndent = getIntOrDefault(attrValue, DEFAULT_BASIC_OFFSET);
+                return true;
+            case CASE_INDENT_PROP:
+                int caseIndent = getIntOrDefault(attrValue, 0);
+                indentCase = caseIndent > 0;
+                return true;
+            case LINE_WRAP_INDENT_PROP:
+                continuationIndent = getIntOrDefault(attrValue, DEFAULT_LINE_WRAP_INDENT);
+                return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void importTo(@NotNull final CodeStyleSettings settings) {
+        CommonCodeStyleSettings javaSettings = getJavaSettings(settings);
+        CommonCodeStyleSettings.IndentOptions indentOptions = javaSettings.getIndentOptions();
+        if (indentOptions != null) {
+            indentOptions.INDENT_SIZE = basicIndent;
+            indentOptions.CONTINUATION_INDENT_SIZE = continuationIndent;
+        }
+        javaSettings.INDENT_CASE_FROM_SWITCH = indentCase;
+    }
+}

--- a/src/main/java/org/infernus/idea/checkstyle/importer/modules/LeftCurlyImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/modules/LeftCurlyImporter.java
@@ -1,0 +1,66 @@
+package org.infernus.idea.checkstyle.importer.modules;
+
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import org.infernus.idea.checkstyle.importer.ModuleImporter;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+@SuppressWarnings("unused")
+public class LeftCurlyImporter extends ModuleImporter {
+    private final static String OPTION_PROP = "option";
+    
+    private final static String LEFT_CURLY_POLICY_EOL   = "eol";
+    private final static String LEFT_CURLY_POLICY_NL    = "nl";
+    private final static String LEFT_CURLY_POLICY_NLOW  = "nlow";
+    
+    private int leftCurlyPolicy = CommonCodeStyleSettings.END_OF_LINE;
+    
+    private final static Set<Integer> CONDITIONAL_TOKENS = setOf(
+            TokenTypes.LITERAL_WHILE,
+            TokenTypes.LITERAL_TRY,
+            TokenTypes.LITERAL_CATCH,
+            TokenTypes.LITERAL_FINALLY,
+            TokenTypes.LITERAL_SYNCHRONIZED,
+            TokenTypes.LITERAL_SWITCH,
+            TokenTypes.LITERAL_DO,
+            TokenTypes.LITERAL_IF,
+            TokenTypes.LITERAL_ELSE,
+            TokenTypes.LITERAL_FOR
+    );
+    
+    @Override
+    protected boolean handleAttribute(@NotNull final String attrName, @NotNull final String attrValue) {
+        if (OPTION_PROP.equals(attrName)) {
+            switch (attrValue) {
+                case LEFT_CURLY_POLICY_EOL:
+                    leftCurlyPolicy = CommonCodeStyleSettings.END_OF_LINE;
+                    break;
+                case LEFT_CURLY_POLICY_NL:
+                    leftCurlyPolicy = CommonCodeStyleSettings.NEXT_LINE;
+                    break;
+                case LEFT_CURLY_POLICY_NLOW:
+                    leftCurlyPolicy = CommonCodeStyleSettings.NEXT_LINE_IF_WRAPPED;
+                    break;
+            }
+            return true;
+        }
+        return super.handleAttribute(attrName, attrValue);
+    }
+
+    @Override
+    public void importTo(@NotNull final CodeStyleSettings settings) {
+        CommonCodeStyleSettings javaSettings = getJavaSettings(settings);
+        if (appliesTo(TokenTypes.CLASS_DEF) || appliesTo(TokenTypes.INTERFACE_DEF)) {
+            javaSettings.CLASS_BRACE_STYLE = leftCurlyPolicy;
+        }
+        if (appliesTo(TokenTypes.METHOD_DEF) || appliesTo(TokenTypes.CTOR_DEF)) {
+            javaSettings.METHOD_BRACE_STYLE = leftCurlyPolicy;
+        }
+        if (appliesToOneOf(CONDITIONAL_TOKENS)) {
+            javaSettings.BRACE_STYLE = leftCurlyPolicy;
+        }
+    }
+}

--- a/src/main/java/org/infernus/idea/checkstyle/importer/modules/LineLengthImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/modules/LineLengthImporter.java
@@ -1,0 +1,32 @@
+package org.infernus.idea.checkstyle.importer.modules;
+
+import com.intellij.lang.java.JavaLanguage;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import org.infernus.idea.checkstyle.importer.ModuleImporter;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public class LineLengthImporter extends ModuleImporter {
+    private static final int DEFAULT_MAX_COLUMNS = 80;
+    private static final String MAX_PROP = "max";
+    private int maxColumns = DEFAULT_MAX_COLUMNS;
+
+    @Override
+    protected boolean handleAttribute(@NotNull final String attrName, @NotNull final String attrValue) {
+        if (MAX_PROP.equals(attrName)) {
+            try {
+                maxColumns = Integer.parseInt(attrValue);
+            }
+            catch (NumberFormatException nfe) {
+                // ignore
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void importTo(@NotNull CodeStyleSettings settings) {
+        settings.setRightMargin(JavaLanguage.INSTANCE, maxColumns);
+    }
+}

--- a/src/main/java/org/infernus/idea/checkstyle/importer/modules/NeedBracesImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/modules/NeedBracesImporter.java
@@ -1,0 +1,42 @@
+package org.infernus.idea.checkstyle.importer.modules;
+
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import org.infernus.idea.checkstyle.importer.ModuleImporter;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public class NeedBracesImporter extends ModuleImporter {
+    private final static String ALLOW_SINGLE_LINE_STATEMENT_PROP = "allowSingleLineStatement";
+    
+    private int forceBraces = CommonCodeStyleSettings.FORCE_BRACES_ALWAYS;
+
+    @Override
+    protected boolean handleAttribute(@NotNull final String attrName, @NotNull final String attrValue) {
+        if (ALLOW_SINGLE_LINE_STATEMENT_PROP.equals(attrName)) {
+            if (Boolean.parseBoolean(attrValue)) {
+                forceBraces = CommonCodeStyleSettings.FORCE_BRACES_IF_MULTILINE;
+            }
+            return true;
+        }
+        return super.handleAttribute(attrName, attrValue);
+    }
+
+    @Override
+    public void importTo(@NotNull final CodeStyleSettings settings) {
+        CommonCodeStyleSettings javaSettings = getJavaSettings(settings);
+        if (appliesTo(TokenTypes.LITERAL_DO)) {
+            javaSettings.DOWHILE_BRACE_FORCE = forceBraces;
+        }
+        if (appliesTo(TokenTypes.LITERAL_FOR)) {
+            javaSettings.FOR_BRACE_FORCE = forceBraces;
+        }
+        if (appliesTo(TokenTypes.LITERAL_IF)) {
+            javaSettings.IF_BRACE_FORCE = forceBraces;
+        }
+        if (appliesTo(TokenTypes.LITERAL_WHILE)) {
+            javaSettings.WHILE_BRACE_FORCE = forceBraces;
+        }
+    }
+}

--- a/src/main/java/org/infernus/idea/checkstyle/importer/modules/NoWhitespaceBeforeImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/modules/NoWhitespaceBeforeImporter.java
@@ -1,0 +1,22 @@
+package org.infernus.idea.checkstyle.importer.modules;
+
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import org.infernus.idea.checkstyle.importer.ModuleImporter;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public class NoWhitespaceBeforeImporter extends ModuleImporter {
+    
+    @Override
+    public void importTo(@NotNull final CodeStyleSettings settings) {
+        CommonCodeStyleSettings javaSettings = getJavaSettings(settings);
+        if (appliesTo(TokenTypes.COMMA)) {
+            javaSettings.SPACE_BEFORE_COMMA = false;
+        }
+        if (appliesTo(TokenTypes.SEMI)) {
+            javaSettings.SPACE_BEFORE_SEMICOLON = false;
+        }
+    }
+}

--- a/src/main/java/org/infernus/idea/checkstyle/importer/modules/WhitespaceAfterImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/modules/WhitespaceAfterImporter.java
@@ -1,0 +1,25 @@
+package org.infernus.idea.checkstyle.importer.modules;
+
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import org.infernus.idea.checkstyle.importer.ModuleImporter;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public class WhitespaceAfterImporter extends ModuleImporter {
+
+    @Override
+    public void importTo(@NotNull final CodeStyleSettings settings) {
+        CommonCodeStyleSettings javaSettings = getJavaSettings(settings);
+        if (appliesTo(TokenTypes.COMMA)) {
+            javaSettings.SPACE_AFTER_COMMA = true;
+        }
+        if (appliesTo(TokenTypes.SEMI)) {
+            javaSettings.SPACE_AFTER_SEMICOLON = true;
+        }
+        if (appliesTo(TokenTypes.TYPECAST)) {
+            javaSettings.SPACE_AFTER_TYPE_CAST = true;
+        }
+    }
+}

--- a/src/main/java/org/infernus/idea/checkstyle/importer/modules/WhitespaceAroundImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/modules/WhitespaceAroundImporter.java
@@ -1,0 +1,156 @@
+package org.infernus.idea.checkstyle.importer.modules;
+
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import org.infernus.idea.checkstyle.importer.ModuleImporter;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+@SuppressWarnings("unused")
+public class WhitespaceAroundImporter extends ModuleImporter {
+
+    private final static Set<Integer> ASSIGNMENTS = 
+            setOf(
+                    TokenTypes.ASSIGN, 
+                    TokenTypes.BAND_ASSIGN, 
+                    TokenTypes.BOR_ASSIGN, 
+                    TokenTypes.BSR_ASSIGN,
+                    TokenTypes.BXOR_ASSIGN,
+                    TokenTypes.DIV_ASSIGN,
+                    TokenTypes.MOD_ASSIGN,
+                    TokenTypes.MINUS_ASSIGN,
+                    TokenTypes.PLUS_ASSIGN,
+                    TokenTypes.SL_ASSIGN,
+                    TokenTypes.SR_ASSIGN,
+                    TokenTypes.STAR_ASSIGN
+            );
+    private final static Set<Integer> LOGICAL_OPERATORS =
+            setOf(
+                    TokenTypes.LOR,
+                    TokenTypes.LAND
+            );
+    private final static Set<Integer> EQUALITY_OPERATORS =
+            setOf(
+                    TokenTypes.EQUAL,
+                    TokenTypes.NOT_EQUAL
+            );
+    private final static Set<Integer> RELATIONAL_OPERATORS =
+            setOf(
+                    TokenTypes.LT,
+                    TokenTypes.LE,
+                    TokenTypes.GT,
+                    TokenTypes.GE
+            );
+    private final static Set<Integer> BITWISE_OPERATORS =
+            setOf(
+                    TokenTypes.BAND,
+                    TokenTypes.BOR,
+                    TokenTypes.BXOR
+            );
+    private final static Set<Integer> ADDITIVE_OPERATORS =
+            setOf(
+                    TokenTypes.PLUS,
+                    TokenTypes.MINUS
+            );
+    private final static Set<Integer> MULTIPLICATIVE_OPERATORS =
+            setOf(
+                    TokenTypes.STAR,
+                    TokenTypes.DIV,
+                    TokenTypes.MOD
+            );
+    private final static Set<Integer> SHIFT_OPERATORS =
+            setOf(
+                    TokenTypes.SR,
+                    TokenTypes.SL,
+                    TokenTypes.BSR
+            );
+    
+    
+    @Override
+    public void importTo(@NotNull final CodeStyleSettings settings) {
+        CommonCodeStyleSettings javaSettings = getJavaSettings(settings);
+        if (appliesToOneOf(ASSIGNMENTS)) {
+            javaSettings.SPACE_AROUND_ASSIGNMENT_OPERATORS = true;
+        }
+        if (appliesToOneOf(LOGICAL_OPERATORS)) {
+            javaSettings.SPACE_AROUND_LOGICAL_OPERATORS = true;
+        }
+        if (appliesToOneOf(EQUALITY_OPERATORS)) {
+            javaSettings.SPACE_AROUND_EQUALITY_OPERATORS = true;
+        }
+        if (appliesToOneOf(RELATIONAL_OPERATORS)) {
+            javaSettings.SPACE_AROUND_RELATIONAL_OPERATORS = true;
+        }
+        if (appliesToOneOf(BITWISE_OPERATORS)) {
+            javaSettings.SPACE_AROUND_BITWISE_OPERATORS = true;
+        }
+        if (appliesToOneOf(ADDITIVE_OPERATORS)) {
+            javaSettings.SPACE_AROUND_ADDITIVE_OPERATORS = true;
+        }
+        if (appliesToOneOf(MULTIPLICATIVE_OPERATORS)) {
+            javaSettings.SPACE_AROUND_MULTIPLICATIVE_OPERATORS = true;
+        }
+        if (appliesToOneOf(SHIFT_OPERATORS)) {
+            javaSettings.SPACE_AROUND_SHIFT_OPERATORS = true;
+        }
+        if (appliesTo(TokenTypes.COLON)) {
+            javaSettings.SPACE_BEFORE_COLON = true;
+            javaSettings.SPACE_AFTER_COLON = true;
+        }
+        if (appliesTo(TokenTypes.QUESTION)) {
+            javaSettings.SPACE_AFTER_QUEST = true;
+            javaSettings.SPACE_BEFORE_QUEST = true;
+        }
+        if (appliesTo(TokenTypes.LITERAL_CATCH)) {
+            javaSettings.SPACE_BEFORE_CATCH_KEYWORD = true;
+            javaSettings.SPACE_BEFORE_CATCH_PARENTHESES = true;
+        }
+        if (appliesTo(TokenTypes.LITERAL_ELSE)) {
+            javaSettings.SPACE_BEFORE_ELSE_KEYWORD = true;
+            javaSettings.SPACE_BEFORE_ELSE_LBRACE = true;
+        }
+        if (appliesTo(TokenTypes.LITERAL_FINALLY)) {
+            javaSettings.SPACE_BEFORE_FINALLY_KEYWORD = true;
+            javaSettings.SPACE_BEFORE_FINALLY_LBRACE = true;
+        }
+        if (appliesTo(TokenTypes.LITERAL_FOR)) {
+            javaSettings.SPACE_BEFORE_FOR_PARENTHESES = true;
+        }
+        if (appliesTo(TokenTypes.LITERAL_IF)) {
+            javaSettings.SPACE_BEFORE_IF_PARENTHESES = true;
+        }
+        if (appliesTo(TokenTypes.DO_WHILE) || appliesTo(TokenTypes.LITERAL_WHILE)) {
+            javaSettings.SPACE_BEFORE_WHILE_KEYWORD = true;
+            javaSettings.SPACE_BEFORE_WHILE_PARENTHESES = true;
+        }
+        if (appliesTo(TokenTypes.LITERAL_DO)) {
+            javaSettings.SPACE_BEFORE_DO_LBRACE = true;
+        }
+        if (appliesTo(TokenTypes.LITERAL_SWITCH)) {
+            javaSettings.SPACE_BEFORE_SWITCH_PARENTHESES = true;
+        }
+        if (appliesTo(TokenTypes.LITERAL_SYNCHRONIZED)) {
+            javaSettings.SPACE_BEFORE_SYNCHRONIZED_PARENTHESES = true;
+        }
+        if (appliesTo(TokenTypes.LITERAL_TRY)) {
+            javaSettings.SPACE_BEFORE_TRY_PARENTHESES = true;
+            javaSettings.SPACE_BEFORE_TRY_LBRACE = true;
+        }
+        if (appliesTo(TokenTypes.LCURLY)) {
+            javaSettings.SPACE_BEFORE_ANNOTATION_ARRAY_INITIALIZER_LBRACE = true;
+            javaSettings.SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE = true;
+            javaSettings.SPACE_BEFORE_CATCH_LBRACE = true;
+            javaSettings.SPACE_BEFORE_CLASS_LBRACE = true;
+            javaSettings.SPACE_BEFORE_DO_LBRACE = true;
+            javaSettings.SPACE_BEFORE_ELSE_LBRACE = true;
+            javaSettings.SPACE_BEFORE_FINALLY_LBRACE = true;
+            javaSettings.SPACE_BEFORE_IF_LBRACE = true;
+            javaSettings.SPACE_BEFORE_METHOD_LBRACE = true;
+            javaSettings.SPACE_BEFORE_SWITCH_LBRACE = true;
+            javaSettings.SPACE_BEFORE_SYNCHRONIZED_LBRACE = true;
+            javaSettings.SPACE_BEFORE_TRY_LBRACE = true;
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -169,6 +169,9 @@
                     canCloseContents="false"
                     factoryClass="org.infernus.idea.checkstyle.toolwindow.CheckStyleToolWindowFactory"
                     icon="/org/infernus/idea/checkstyle/images/checkstyle13.png"/>
+        <schemeImporter name="CheckStyle Configuration"
+                        schemeClass="com.intellij.psi.codeStyle.CodeStyleScheme"
+                        implementationClass="org.infernus.idea.checkstyle.importer.CheckStyleCodeStyleImporter"/>
     </extensions>
 
     <actions>

--- a/src/test/java/org/infernus/idea/checkstyle/importer/CodeStyleImporterTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/importer/CodeStyleImporterTest.java
@@ -1,0 +1,219 @@
+package org.infernus.idea.checkstyle.importer;
+
+
+import com.intellij.lang.java.JavaLanguage;
+import com.intellij.lang.xml.XMLLanguage;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.intellij.testFramework.LightPlatformTestCase;
+import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import org.jetbrains.annotations.NotNull;
+import org.xml.sax.InputSource;
+
+import java.io.StringReader;
+
+public class CodeStyleImporterTest extends LightPlatformTestCase {
+    private CodeStyleSettings codeStyleSettings;
+    private CommonCodeStyleSettings javaSettings;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        codeStyleSettings = new CodeStyleSettings(false);
+        javaSettings = codeStyleSettings.getCommonSettings(JavaLanguage.INSTANCE);
+    }
+
+    private final static String FILE_PREFIX = 
+            "<?xml version=\"1.0\"?>\n" +
+            "<!DOCTYPE module PUBLIC\n" +
+            "          \"-//Puppy Crawl//DTD Check Configuration 1.3//EN\"\n" +
+            "          \"http://www.puppycrawl.com/dtds/configuration_1_3.dtd\">\n" +
+            "<module name = \"Checker\">\n";
+    private final static String FILE_SUFFIX =
+            "</module>";
+    
+    private void importConfiguration(@NotNull String configuration) throws Exception {
+        configuration = FILE_PREFIX + configuration + FILE_SUFFIX;
+        CheckStyleCodeStyleImporter.importConfiguration(loadConfiguration(configuration), codeStyleSettings);
+    }
+    
+    private String inTreeWalker(@NotNull String configuration) {
+        return "<module name=\"TreeWalker\">" + configuration + "</module>";
+    }
+    
+    private Configuration loadConfiguration(@NotNull String configuration) throws CheckstyleException {
+        InputSource inputSource = new InputSource(new StringReader(configuration));
+        return ConfigurationLoader.loadConfiguration(inputSource, null, false);
+    }
+    
+    public void testImportRightMargin() throws Exception {
+        importConfiguration(
+                inTreeWalker(
+                        "<module name=\"LineLength\">\n" +
+                        "    <property name=\"max\" value=\"100\"/>\n" +
+                        "</module>"
+                )
+        );
+        assertEquals(100, javaSettings.RIGHT_MARGIN);
+    }
+    
+    public void testEmptyLineSeparator() throws Exception {
+        javaSettings.BLANK_LINES_AROUND_FIELD = 0;
+        javaSettings.BLANK_LINES_AROUND_METHOD = 0;
+        importConfiguration(
+                inTreeWalker(
+                        "<module name=\"EmptyLineSeparator\">\n" +
+                        "    <property name=\"tokens\" value=\"VARIABLE_DEF, METHOD_DEF\"/>\n" +
+                        "</module>"
+                )
+        );
+        assertEquals(1, javaSettings.BLANK_LINES_AROUND_FIELD);
+        assertEquals(1, javaSettings.BLANK_LINES_AROUND_METHOD);
+    }
+    
+    public void testImportFileTabCharacter() throws Exception {
+        CommonCodeStyleSettings xmlSettings = codeStyleSettings.getCommonSettings(XMLLanguage.INSTANCE);
+        CommonCodeStyleSettings.IndentOptions javaIndentOptions = javaSettings.getIndentOptions();
+        assertNotNull(javaIndentOptions);
+        CommonCodeStyleSettings.IndentOptions xmlIndentOptions = xmlSettings.getIndentOptions();
+        assertNotNull(xmlIndentOptions);
+        javaIndentOptions.USE_TAB_CHARACTER = true;
+        xmlIndentOptions.USE_TAB_CHARACTER = true;
+        importConfiguration(
+                inTreeWalker(
+                        "<module name=\"FileTabCharacter\">\n" +
+                        "    <property name=\"eachLine\" value=\"true\" />\n" +
+                        "    <property name=\"fileExtensions\" value=\"java,xml\" />\n" +
+                        "</module>"
+                )
+        );
+        assertFalse(javaIndentOptions.USE_TAB_CHARACTER);
+        assertFalse(xmlIndentOptions.USE_TAB_CHARACTER);
+    }
+    
+    public void testImportFileTabCharacterNoExplicitExtensions() throws Exception {
+        CommonCodeStyleSettings xmlSettings = codeStyleSettings.getCommonSettings(XMLLanguage.INSTANCE);
+        CommonCodeStyleSettings.IndentOptions javaIndentOptions = javaSettings.getIndentOptions();
+        assertNotNull(javaIndentOptions);
+        CommonCodeStyleSettings.IndentOptions xmlIndentOptions = xmlSettings.getIndentOptions();
+        assertNotNull(xmlIndentOptions);
+        javaIndentOptions.USE_TAB_CHARACTER = true;
+        xmlIndentOptions.USE_TAB_CHARACTER = true;
+        importConfiguration(
+                inTreeWalker(
+                        "<module name=\"FileTabCharacter\"/>\n"
+                )
+        );
+        assertFalse(javaIndentOptions.USE_TAB_CHARACTER);
+        assertFalse(xmlIndentOptions.USE_TAB_CHARACTER);
+    }
+    
+    public void testImportWhitespaceAfter() throws Exception {
+        javaSettings.SPACE_AFTER_COMMA = false;
+        javaSettings.SPACE_AFTER_SEMICOLON = false;
+        javaSettings.SPACE_AFTER_TYPE_CAST = false;
+        importConfiguration(
+                inTreeWalker(
+                        "<module name=\"WhitespaceAfter\">\n" +
+                        "    <property name=\"tokens\" value=\"COMMA, SEMI\"/>\n" +
+                        "</module>"
+                )
+        );
+        assertTrue(javaSettings.SPACE_AFTER_COMMA);
+        assertTrue(javaSettings.SPACE_AFTER_SEMICOLON);
+        assertFalse(javaSettings.SPACE_AFTER_TYPE_CAST);
+    }
+    
+    public void testImportWhitespaceAround() throws Exception {
+        javaSettings.SPACE_AROUND_ASSIGNMENT_OPERATORS = false;
+        javaSettings.SPACE_AROUND_EQUALITY_OPERATORS = false;
+        javaSettings.SPACE_AROUND_BITWISE_OPERATORS = false;
+        importConfiguration(
+                inTreeWalker(
+                        "<module name=\"WhitespaceAround\">\n" +
+                        "    <property name=\"tokens\" value=\"ASSIGN\"/>\n" +
+                        "    <property name=\"tokens\" value=\"EQUAL\"/>\n" +
+                        "</module>"
+                )
+        );
+        assertTrue(javaSettings.SPACE_AROUND_ASSIGNMENT_OPERATORS);
+        assertTrue(javaSettings.SPACE_AROUND_EQUALITY_OPERATORS);
+        assertFalse(javaSettings.SPACE_AROUND_BITWISE_OPERATORS);
+    }
+    
+    public void testNoWhitespaceBeforeImporter() throws Exception {
+        javaSettings.SPACE_BEFORE_SEMICOLON = true;
+        javaSettings.SPACE_BEFORE_COMMA = true;
+        importConfiguration(
+                inTreeWalker(
+                        "<module name=\"NoWhitespaceBefore\"/>"
+                )
+        );
+        assertFalse(javaSettings.SPACE_BEFORE_SEMICOLON);
+        assertFalse(javaSettings.SPACE_BEFORE_COMMA);
+    }
+    
+    public void testLeftCurlyImporter() throws Exception {
+        javaSettings.CLASS_BRACE_STYLE = CommonCodeStyleSettings.NEXT_LINE_SHIFTED;
+        javaSettings.METHOD_BRACE_STYLE =  CommonCodeStyleSettings.NEXT_LINE_SHIFTED;
+        javaSettings.BRACE_STYLE = CommonCodeStyleSettings.NEXT_LINE_SHIFTED;
+        importConfiguration(
+                inTreeWalker(
+                        "<module name=\"LeftCurly\">\n" +
+                        "    <property name=\"option\" value=\"nl\"/>\n" +
+                        "    <property name=\"tokens\" value=\"CLASS_DEF,INTERFACE_DEF\"/>\n" +
+                        "</module>\n" +
+                        "<module name=\"LeftCurly\">\n" +
+                        "    <property name=\"option\" value=\"eol\"/>\n" +
+                        "    <property name=\"tokens\" value=\"METHOD_DEF,LITERAL_IF\"/>\n" +
+                        "</module>"
+                )
+        );
+        assertEquals(CommonCodeStyleSettings.NEXT_LINE, javaSettings.CLASS_BRACE_STYLE);
+        assertEquals(CommonCodeStyleSettings.END_OF_LINE, javaSettings.METHOD_BRACE_STYLE);
+        assertEquals(CommonCodeStyleSettings.END_OF_LINE, javaSettings.BRACE_STYLE);
+    }
+    
+    public void testNeedBracesImporter() throws Exception {
+        javaSettings.DOWHILE_BRACE_FORCE = CommonCodeStyleSettings.DO_NOT_FORCE;
+        javaSettings.IF_BRACE_FORCE = CommonCodeStyleSettings.DO_NOT_FORCE;
+        javaSettings.FOR_BRACE_FORCE = CommonCodeStyleSettings.DO_NOT_FORCE;
+        importConfiguration(
+                inTreeWalker(
+                        "<module name=\"NeedBraces\">\n" +
+                        "    <property name=\"allowSingleLineStatement\" value=\"true\"/>\n" +
+                        "</module>"
+                )
+        );
+        assertEquals(CommonCodeStyleSettings.FORCE_BRACES_IF_MULTILINE, javaSettings.DOWHILE_BRACE_FORCE);
+        assertEquals(CommonCodeStyleSettings.FORCE_BRACES_IF_MULTILINE, javaSettings.IF_BRACE_FORCE);
+        assertEquals(CommonCodeStyleSettings.FORCE_BRACES_IF_MULTILINE, javaSettings.FOR_BRACE_FORCE);
+    }
+    
+    public void testIndentationImporter() throws Exception {
+        javaSettings.INDENT_BREAK_FROM_CASE = false;
+        CommonCodeStyleSettings.IndentOptions indentOptions = javaSettings.getIndentOptions();
+        assertNotNull(indentOptions);
+        indentOptions.INDENT_SIZE = 8;
+        indentOptions.CONTINUATION_INDENT_SIZE = 8;
+        importConfiguration(
+                inTreeWalker(
+                        " <module name=\"Indentation\">\n" +
+                        "            <property name=\"basicOffset\" value=\"2\"/>\n" +
+                        "            <property name=\"braceAdjustment\" value=\"0\"/>\n" +
+                        "            <property name=\"caseIndent\" value=\"2\"/>\n" +
+                        "            <property name=\"throwsIndent\" value=\"4\"/>\n" +
+                        "            <property name=\"lineWrappingIndentation\" value=\"4\"/>\n" +
+                        "            <property name=\"arrayInitIndent\" value=\"2\"/>\n" +
+                        "</module>"
+                )
+        );
+        javaSettings.INDENT_BREAK_FROM_CASE = true;
+        indentOptions.INDENT_SIZE = 2;
+        indentOptions.CONTINUATION_INDENT_SIZE = 4;
+    }
+    
+    
+}


### PR DESCRIPTION
Imports Checkstyle configuration to the current code style scheme by processing whitespace, indentation, etc. modules. Takes the best possible match approach since not all the options can be mapped one-to-one.