### PR TITLE
Switch from Java Executors to IntelliJ JobSchedule to allow IntelliJ …

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/ui/LocationDialogue.java
+++ b/src/main/java/org/infernus/idea/checkstyle/ui/LocationDialogue.java
@@ -202,8 +202,6 @@ public class LocationDialogue extends JDialog {
             errorPanel.setError(e);
             return Step.ERROR;
 
-        } finally {
-            cache.shutdown();
         }
     }
 


### PR DESCRIPTION
To allow IntelliJ To manage the cached checker cleanup thread, use the JobScheduler. Note that this is an unbounded scheduler so please consider whether that has any implications cleaner. I also switched to using a fixed delay scheduler rather than a fixed rate scheduler because of a comment in the AppExecutorUtil class in the 2016 code base which indicated that this is better for hibernation. Since we are using an IntelliJ managed thread pool, calling shutdown is prohibited.

I have only run the unit tests, so please perform any additional tests at your discretion.