### PR TITLE
squid:S1118 - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/importer/ModuleImporterFactory.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/ModuleImporterFactory.java
@@ -6,6 +6,8 @@ import org.jetbrains.annotations.Nullable;
 
 class ModuleImporterFactory {
 
+    private ModuleImporterFactory() {}
+
     @Nullable
     static ModuleImporter getModuleImporter(@NotNull Configuration configuration)
             throws InstantiationException, IllegalAccessException {

--- a/src/main/java/org/infernus/idea/checkstyle/util/Async.java
+++ b/src/main/java/org/infernus/idea/checkstyle/util/Async.java
@@ -11,6 +11,8 @@ import java.util.concurrent.Future;
 public class Async {
     private static final int FIFTY_MS = 50;
 
+    private Async() {}
+
     @Nullable
     public static <T> T asyncResultOf(@NotNull final Callable<T> callable,
                                       @Nullable final T defaultValue) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava