### PR TITLE
squid:S1168 -  Empty arrays and collections should be returned instead of null

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/CheckStyleConfiguration.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckStyleConfiguration.java
@@ -233,7 +233,7 @@ public final class CheckStyleConfiguration implements ExportableComponent,
             removeUnknownProperties();
 
             if (configurationLocations == null) {
-                return null;
+                return Collections.emptyList();
             }
 
             int index = 0;

--- a/src/main/java/org/infernus/idea/checkstyle/model/InsecureHTTPURLConfigurationLocation.java
+++ b/src/main/java/org/infernus/idea/checkstyle/model/InsecureHTTPURLConfigurationLocation.java
@@ -38,7 +38,7 @@ public class InsecureHTTPURLConfigurationLocation extends HTTPURLConfigurationLo
 
     private static class AllTrustingTrustManager implements X509TrustManager {
         public X509Certificate[] getAcceptedIssuers() {
-            return null;
+            return new X509Certificate[] {};
         }
 
         public void checkClientTrusted(final X509Certificate[] certs, final String authType) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1168 -  Empty arrays and collections should be returned instead of null.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1168
Please let me know if you have any questions.
George Kankava