### PR TITLE
squid:S1168 - Empty arrays and collections should be returned instead of null

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/CheckStyleModuleConfiguration.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckStyleModuleConfiguration.java
@@ -68,7 +68,7 @@ public final class CheckStyleModuleConfiguration extends Properties
 
     public boolean isExcluded() {
         return containsKey(EXCLUDE_FROM_SCAN)
-                && getProperty(EXCLUDE_FROM_SCAN, "false").equalsIgnoreCase("true");
+                && "true".equalsIgnoreCase(getProperty(EXCLUDE_FROM_SCAN, "false"));
     }
 
     public boolean isUsingModuleConfiguration() {

--- a/src/main/java/org/infernus/idea/checkstyle/model/ConfigurationType.java
+++ b/src/main/java/org/infernus/idea/checkstyle/model/ConfigurationType.java
@@ -42,7 +42,7 @@ public enum ConfigurationType {
         }
 
         final String processedType = typeAsString.toUpperCase().replace(' ', '_');
-        if (processedType.equals("FILE")) {
+        if ("FILE".equals(processedType)) {
             return LOCAL_FILE;
         }
 

--- a/src/main/java/org/infernus/idea/checkstyle/util/FilePaths.java
+++ b/src/main/java/org/infernus/idea/checkstyle/util/FilePaths.java
@@ -35,11 +35,11 @@ public final class FilePaths {
         String normalizedBasePath = FilenameUtils.normalizeNoEndSeparator(basePath);
 
         // Undo the changes to the separators made by normalization
-        if (pathSeparator.equals("/")) {
+        if ("/".equals(pathSeparator)) {
             normalizedTargetPath = FilenameUtils.separatorsToUnix(normalizedTargetPath);
             normalizedBasePath = FilenameUtils.separatorsToUnix(normalizedBasePath);
 
-        } else if (pathSeparator.equals("\\")) {
+        } else if ("\\".equals(pathSeparator)) {
             normalizedTargetPath = FilenameUtils.separatorsToWindows(normalizedTargetPath);
             normalizedBasePath = FilenameUtils.separatorsToWindows(normalizedBasePath);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1168 - Empty arrays and collections should be returned instead of null.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1168
Please let me know if you have any questions.
George Kankava