### PR TITLE
squid:S1161 - '@Override' annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/actions/ScanSourceRootsAction.java
+++ b/src/main/java/org/infernus/idea/checkstyle/actions/ScanSourceRootsAction.java
@@ -22,6 +22,7 @@ class ScanSourceRootsAction implements Runnable {
         this.selectedOverride = selectedOverride;
     }
 
+    @Override
     public void run() {
         project.getComponent(CheckStylePlugin.class)
                 .asyncScanFiles(flattenFiles(sourceRoots), selectedOverride);

--- a/src/main/java/org/infernus/idea/checkstyle/checker/CheckStyleAuditListener.java
+++ b/src/main/java/org/infernus/idea/checkstyle/checker/CheckStyleAuditListener.java
@@ -97,6 +97,7 @@ public class CheckStyleAuditListener implements AuditListener {
 
     private class ProcessResultsThread implements Runnable {
 
+        @Override
         public void run() {
             final Map<PsiFile, List<Integer>> lineLengthCachesByFile = new HashMap<>();
 

--- a/src/main/java/org/infernus/idea/checkstyle/checker/CheckerFactoryWorker.java
+++ b/src/main/java/org/infernus/idea/checkstyle/checker/CheckerFactoryWorker.java
@@ -36,6 +36,7 @@ class CheckerFactoryWorker extends Thread {
         return threadReturn[0];
     }
 
+    @Override
     public void run() {
         try {
             Configuration config = ConfigurationLoader.loadConfiguration(new InputSource(location.resolve()), resolver, true);

--- a/src/main/java/org/infernus/idea/checkstyle/checker/CreateScannableFileAction.java
+++ b/src/main/java/org/infernus/idea/checkstyle/checker/CreateScannableFileAction.java
@@ -55,6 +55,7 @@ class CreateScannableFileAction implements Runnable {
         return file;
     }
 
+    @Override
     public void run() {
         try {
             file = new ScannableFile(psiFile, module);

--- a/src/main/java/org/infernus/idea/checkstyle/model/InsecureHTTPURLConfigurationLocation.java
+++ b/src/main/java/org/infernus/idea/checkstyle/model/InsecureHTTPURLConfigurationLocation.java
@@ -37,13 +37,16 @@ public class InsecureHTTPURLConfigurationLocation extends HTTPURLConfigurationLo
     }
 
     private static class AllTrustingTrustManager implements X509TrustManager {
+        @Override
         public X509Certificate[] getAcceptedIssuers() {
             return null;
         }
 
+        @Override
         public void checkClientTrusted(final X509Certificate[] certs, final String authType) {
         }
 
+        @Override
         public void checkServerTrusted(final X509Certificate[] certs, final String authType) {
         }
     }

--- a/src/main/java/org/infernus/idea/checkstyle/toolwindow/CheckStyleToolWindowPanel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/toolwindow/CheckStyleToolWindowPanel.java
@@ -406,6 +406,7 @@ public class CheckStyleToolWindowPanel extends JPanel implements ConfigurationLi
      */
     protected class ToolWindowSelectionListener implements TreeSelectionListener {
 
+        @Override
         public void valueChanged(final TreeSelectionEvent e) {
             if (!scrollToSource) {
                 return;

--- a/src/main/java/org/infernus/idea/checkstyle/toolwindow/ResultTreeNode.java
+++ b/src/main/java/org/infernus/idea/checkstyle/toolwindow/ResultTreeNode.java
@@ -193,6 +193,7 @@ public class ResultTreeNode {
         this.description = description;
     }
 
+    @Override
     public String toString() {
         if (text != null) {
             return text;

--- a/src/main/java/org/infernus/idea/checkstyle/toolwindow/ResultTreeRenderer.java
+++ b/src/main/java/org/infernus/idea/checkstyle/toolwindow/ResultTreeRenderer.java
@@ -21,6 +21,7 @@ public class ResultTreeRenderer extends JLabel
         setOpaque(false);
     }
 
+    @Override
     public void paintComponent(final Graphics g) {
         g.setColor(getBackground());
 
@@ -39,6 +40,7 @@ public class ResultTreeRenderer extends JLabel
         super.paintComponent(g);
     }
 
+    @Override
     public Component getTreeCellRendererComponent(final JTree tree,
                                                   final Object value,
                                                   final boolean selected,

--- a/src/main/java/org/infernus/idea/checkstyle/ui/CheckStyleConfigPanel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/ui/CheckStyleConfigPanel.java
@@ -320,6 +320,7 @@ public final class CheckStyleConfigPanel extends JPanel {
             putValue(Action.LONG_DESCRIPTION, CheckStyleBundle.message("config.file.add.tooltip"));
         }
 
+        @Override
         public void actionPerformed(final ActionEvent e) {
             final LocationDialogue dialogue = new LocationDialogue(project, getThirdPartyClasspath());
 
@@ -351,6 +352,7 @@ public final class CheckStyleConfigPanel extends JPanel {
             putValue(Action.LONG_DESCRIPTION, CheckStyleBundle.message("config.file.remove.tooltip"));
         }
 
+        @Override
         public void actionPerformed(final ActionEvent e) {
             final int selectedIndex = locationTable.getSelectedRow();
             if (selectedIndex == -1) {
@@ -373,6 +375,7 @@ public final class CheckStyleConfigPanel extends JPanel {
             putValue(Action.LONG_DESCRIPTION, CheckStyleBundle.message("config.file.properties.tooltip"));
         }
 
+        @Override
         public void actionPerformed(final ActionEvent e) {
             final int selectedIndex = locationTable.getSelectedRow();
             if (selectedIndex == -1) {
@@ -417,6 +420,7 @@ public final class CheckStyleConfigPanel extends JPanel {
             putValue(Action.LONG_DESCRIPTION, CheckStyleBundle.message("config.path.add.tooltip"));
         }
 
+        @Override
         public void actionPerformed(final ActionEvent e) {
             final FileChooserDescriptor descriptor = new ExtensionFileChooserDescriptor(
                     (String) getValue(Action.NAME),
@@ -445,6 +449,7 @@ public final class CheckStyleConfigPanel extends JPanel {
             putValue(Action.LONG_DESCRIPTION, CheckStyleBundle.message("config.path.edit.tooltip"));
         }
 
+        @Override
         public void actionPerformed(final ActionEvent e) {
             final int selected = pathList.getSelectedIndex();
             if (selected < 0) {
@@ -483,6 +488,7 @@ public final class CheckStyleConfigPanel extends JPanel {
             putValue(Action.LONG_DESCRIPTION, CheckStyleBundle.message("config.path.remove.tooltip"));
         }
 
+        @Override
         public void actionPerformed(final ActionEvent e) {
             final int[] selected = pathList.getSelectedIndices();
             if (selected == null || selected.length == 0) {
@@ -510,6 +516,7 @@ public final class CheckStyleConfigPanel extends JPanel {
             putValue(Action.LONG_DESCRIPTION, CheckStyleBundle.message("config.path.move-up.tooltip"));
         }
 
+        @Override
         public void actionPerformed(final ActionEvent e) {
             final int selected = pathList.getSelectedIndex();
             if (selected < 1) {
@@ -539,6 +546,7 @@ public final class CheckStyleConfigPanel extends JPanel {
             putValue(Action.LONG_DESCRIPTION, CheckStyleBundle.message("config.path.move-down.tooltip"));
         }
 
+        @Override
         public void actionPerformed(final ActionEvent e) {
             final DefaultListModel<String> listModel = pathListModel();
             final int selected = pathList.getSelectedIndex();

--- a/src/main/java/org/infernus/idea/checkstyle/ui/CheckStyleModuleConfigPanel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/ui/CheckStyleModuleConfigPanel.java
@@ -197,6 +197,7 @@ public class CheckStyleModuleConfigPanel extends JPanel {
      */
     private class RadioListener implements ActionListener {
 
+        @Override
         public void actionPerformed(final ActionEvent e) {
             final boolean showModuleConfig = useModuleConfigurationRadio.isSelected();
 

--- a/src/main/java/org/infernus/idea/checkstyle/ui/LocationDialogue.java
+++ b/src/main/java/org/infernus/idea/checkstyle/ui/LocationDialogue.java
@@ -210,6 +210,7 @@ public class LocationDialogue extends JDialog {
     private class NextAction extends AbstractAction {
         private static final long serialVersionUID = 3800521701284308642L;
 
+        @Override
         public void actionPerformed(final ActionEvent event) {
             commitButton.setEnabled(false);
 
@@ -316,6 +317,7 @@ public class LocationDialogue extends JDialog {
             putValue(Action.LONG_DESCRIPTION, CheckStyleBundle.message("config.file.cancel.tooltip"));
         }
 
+        @Override
         public void actionPerformed(final ActionEvent e) {
             committed = false;
 

--- a/src/main/java/org/infernus/idea/checkstyle/ui/LocationPanel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/ui/LocationPanel.java
@@ -218,6 +218,7 @@ public class LocationPanel extends JPanel {
                     CheckStyleBundle.message("config.file.browse.tooltip"));
         }
 
+        @Override
         public void actionPerformed(final ActionEvent e) {
             final VirtualFile toSelect;
             final String configFilePath = fileLocationField.getText();
@@ -243,6 +244,7 @@ public class LocationPanel extends JPanel {
      * Handles radio button selections.
      */
     protected final class RadioButtonActionListener implements ActionListener {
+        @Override
         public void actionPerformed(final ActionEvent e) {
             if (urlLocationRadio.isSelected()) {
                 enabledURLLocation();

--- a/src/main/java/org/infernus/idea/checkstyle/ui/LocationTableModel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/ui/LocationTableModel.java
@@ -147,10 +147,12 @@ public class LocationTableModel extends AbstractTableModel {
         return Collections.unmodifiableList(locations);
     }
 
+    @Override
     public int getColumnCount() {
         return NUMBER_OF_COLUMNS;
     }
 
+    @Override
     public Class<?> getColumnClass(final int columnIndex) {
         switch (columnIndex) {
             case COLUMN_ACTIVE:
@@ -161,10 +163,12 @@ public class LocationTableModel extends AbstractTableModel {
         }
     }
 
+    @Override
     public String getColumnName(final int column) {
         return CheckStyleBundle.message("config.file.locations.table." + column);
     }
 
+    @Override
     public boolean isCellEditable(final int rowIndex, final int columnIndex) {
         return columnIndex == COLUMN_ACTIVE;
     }
@@ -183,10 +187,12 @@ public class LocationTableModel extends AbstractTableModel {
         }
     }
 
+    @Override
     public int getRowCount() {
         return locations.size();
     }
 
+    @Override
     public Object getValueAt(final int rowIndex, final int columnIndex) {
         switch (columnIndex) {
             case COLUMN_ACTIVE:

--- a/src/main/java/org/infernus/idea/checkstyle/ui/PropertiesDialogue.java
+++ b/src/main/java/org/infernus/idea/checkstyle/ui/PropertiesDialogue.java
@@ -122,6 +122,7 @@ public class PropertiesDialogue extends JDialog {
                     CheckStyleBundle.message("config.file.okay.tooltip"));
         }
 
+        @Override
         public void actionPerformed(final ActionEvent event) {
             committed = true;
             setVisible(false);
@@ -143,6 +144,7 @@ public class PropertiesDialogue extends JDialog {
             putValue(Action.LONG_DESCRIPTION, CheckStyleBundle.message("config.file.cancel.tooltip"));
         }
 
+        @Override
         public void actionPerformed(final ActionEvent e) {
             committed = false;
 

--- a/src/main/java/org/infernus/idea/checkstyle/ui/PropertiesTableModel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/ui/PropertiesTableModel.java
@@ -72,22 +72,27 @@ public class PropertiesTableModel extends AbstractTableModel {
         return new HashMap<>(properties);
     }
 
+    @Override
     public int getColumnCount() {
         return NUMBER_OF_COLUMNS;
     }
 
+    @Override
     public Class<?> getColumnClass(final int columnIndex) {
         return String.class;
     }
 
+    @Override
     public String getColumnName(final int column) {
         return CheckStyleBundle.message("config.file.properties.table." + column);
     }
 
+    @Override
     public boolean isCellEditable(final int rowIndex, final int columnIndex) {
         return columnIndex == COLUMN_VALUE;
     }
 
+    @Override
     public void setValueAt(final Object aValue, final int rowIndex,
                            final int columnIndex) {
         switch (columnIndex) {
@@ -103,10 +108,12 @@ public class PropertiesTableModel extends AbstractTableModel {
         }
     }
 
+    @Override
     public int getRowCount() {
         return orderedNames.size();
     }
 
+    @Override
     public Object getValueAt(final int rowIndex, final int columnIndex) {
         switch (columnIndex) {
             case COLUMN_NAME:

--- a/src/main/java/org/infernus/idea/checkstyle/util/CheckStyleEntityResolver.java
+++ b/src/main/java/org/infernus/idea/checkstyle/util/CheckStyleEntityResolver.java
@@ -64,6 +64,7 @@ public class CheckStyleEntityResolver implements EntityResolver {
 
     }
 
+    @Override
     public InputSource resolveEntity(final String publicId,
                                      final String systemId)
             throws SAXException, IOException {
@@ -101,6 +102,7 @@ public class CheckStyleEntityResolver implements EntityResolver {
             this.systemId = systemId;
         }
 
+        @Override
         public boolean equals(final Object o) {
             if (this == o) {
                 return true;
@@ -121,6 +123,7 @@ public class CheckStyleEntityResolver implements EntityResolver {
             return true;
         }
 
+        @Override
         public int hashCode() {
             return 31 * publicId.hashCode() + systemId.hashCode();
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1161 - '@Override' annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1161
Please let me know if you have any questions.
George Kankava