### PR TITLE
squid:S2142 - 'InterruptedException' should not be ignored

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/checker/CheckerFactory.java
+++ b/src/main/java/org/infernus/idea/checkstyle/checker/CheckerFactory.java
@@ -195,6 +195,7 @@ public class CheckerFactory {
             try {
                 worker.join();
             } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
             }
         }
 

--- a/src/main/java/org/infernus/idea/checkstyle/util/Async.java
+++ b/src/main/java/org/infernus/idea/checkstyle/util/Async.java
@@ -39,6 +39,7 @@ public class Async {
             Thread.sleep(millis);
         } catch (InterruptedException ignored) {
             // ignored
+            Thread.currentThread().interrupt();
         }
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2142 - 'InterruptedException' should not be ignored
You can find more information about the issue here:
InterruptedExceptions should never be ignored in the code, and simply logging the exception counts in this case as "ignoring". Instead, InterruptedExceptions should either be rethrown - immediately or after cleaning up the method's state - or the method should be reinterrupted. Any other course of action risks delaying thread shutdown and loses the information that the thread was interrupted - probably without finishing its task.
Please let me know if you have any questions.
George Kankava