### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/toolwindow/CheckStyleToolWindowPanel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/toolwindow/CheckStyleToolWindowPanel.java
@@ -216,7 +216,7 @@ public class CheckStyleToolWindowPanel extends JPanel implements ConfigurationLi
 
         for (Content currentContent : toolWindow.getContentManager().getContents()) {
             if (currentContent.getComponent() instanceof CheckStyleToolWindowPanel) {
-                return ((CheckStyleToolWindowPanel) currentContent.getComponent());
+                return (CheckStyleToolWindowPanel) currentContent.getComponent();
             }
         }
 

--- a/src/main/java/org/infernus/idea/checkstyle/toolwindow/ResultTreeRenderer.java
+++ b/src/main/java/org/infernus/idea/checkstyle/toolwindow/ResultTreeRenderer.java
@@ -30,11 +30,11 @@ public class ResultTreeRenderer extends JLabel
             offset = getIcon().getIconWidth() + getIconTextGap();
         }
 
-        g.fillRect(offset, 0, (getWidth() - 1 - offset), (getHeight() - 1));
+        g.fillRect(offset, 0, getWidth() - 1 - offset, getHeight() - 1);
 
         if (selected) {
             g.setColor(UIManager.getColor("Tree.selectionBorderColor"));
-            g.drawRect(offset, 0, (getWidth() - 1 - offset), (getHeight() - 1));
+            g.drawRect(offset, 0, getWidth() - 1 - offset, getHeight() - 1);
         }
 
         super.paintComponent(g);

--- a/src/main/java/org/infernus/idea/checkstyle/ui/LocationPanel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/ui/LocationPanel.java
@@ -168,7 +168,7 @@ public class LocationPanel extends JPanel {
             return false;
         }
         for (int i = 0; i < strLen; i++) {
-            if ((!Character.isWhitespace(str.charAt(i)))) {
+            if (!Character.isWhitespace(str.charAt(i))) {
                 return true;
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava