### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/CheckStylePlugin.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckStylePlugin.java
@@ -99,7 +99,7 @@ public final class CheckStylePlugin implements ProjectComponent {
      */
     public boolean isScanInProgress() {
         synchronized (checksInProgress) {
-            return checksInProgress.size() > 0;
+            return !checksInProgress.isEmpty();
         }
     }
 

--- a/src/main/java/org/infernus/idea/checkstyle/actions/ScanModifiedFiles.java
+++ b/src/main/java/org/infernus/idea/checkstyle/actions/ScanModifiedFiles.java
@@ -68,7 +68,7 @@ public class ScanModifiedFiles extends BaseAction {
 
             // disable if no files are modified
             final List<VirtualFile> modifiedFiles = ChangeListManager.getInstance(project).getAffectedFiles();
-            if (modifiedFiles.size() == 0) {
+            if (modifiedFiles.isEmpty()) {
                 presentation.setEnabled(false);
 
             } else {

--- a/src/main/java/org/infernus/idea/checkstyle/ui/CheckStyleModuleConfigPanel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/ui/CheckStyleModuleConfigPanel.java
@@ -111,12 +111,12 @@ public class CheckStyleModuleConfigPanel extends JPanel {
 
         configurationFilesModel.removeAllElements();
 
-        if (locations != null && locations.size() > 0) {
+        if (locations != null && !locations.isEmpty()) {
             locations.forEach(configurationFilesModel::addElement);
             configurationFilesModel.setSelectedItem(locations.get(0));
         }
 
-        useModuleConfigurationRadio.setEnabled(locations != null && locations.size() > 0);
+        useModuleConfigurationRadio.setEnabled(locations != null && !locations.isEmpty());
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava