### PR TITLE
squid:S3027 - String function use should be optimized for single characters

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/model/ConfigurationLocation.java
+++ b/src/main/java/org/infernus/idea/checkstyle/model/ConfigurationLocation.java
@@ -168,7 +168,7 @@ public abstract class ConfigurationLocation implements Cloneable, Comparable<Con
         }
 
         final int propertyStart = value.indexOf("${");
-        final int propertyEnd = value.indexOf("}");
+        final int propertyEnd = value.indexOf('}');
         if (propertyStart >= 0 && propertyEnd >= 0) {
             final String propertyName = value.substring(
                     propertyStart + 2, propertyEnd);

--- a/src/main/java/org/infernus/idea/checkstyle/model/ConfigurationLocationFactory.java
+++ b/src/main/java/org/infernus/idea/checkstyle/model/ConfigurationLocationFactory.java
@@ -94,7 +94,7 @@ public class ConfigurationLocationFactory {
             throw new IllegalArgumentException("A non-blank representation is required");
         }
 
-        final int typeSplitIndex = stringRepresentation.indexOf(":");
+        final int typeSplitIndex = stringRepresentation.indexOf(':');
         if (typeSplitIndex <= 0 || typeSplitIndex >= stringRepresentation.length() - 1) {
             throw new IllegalArgumentException("Invalid string representation: " + stringRepresentation);
         }
@@ -102,7 +102,7 @@ public class ConfigurationLocationFactory {
         final String typeString = stringRepresentation.substring(0, typeSplitIndex);
 
 
-        final int descriptionSplitIndex = stringRepresentation.lastIndexOf(":");
+        final int descriptionSplitIndex = stringRepresentation.lastIndexOf(':');
         if (descriptionSplitIndex <= 0) {
             throw new IllegalArgumentException("Invalid string representation: " + stringRepresentation);
         }

--- a/src/main/java/org/infernus/idea/checkstyle/model/FileConfigurationLocation.java
+++ b/src/main/java/org/infernus/idea/checkstyle/model/FileConfigurationLocation.java
@@ -116,7 +116,7 @@ public class FileConfigurationLocation extends ConfigurationLocation {
 
     private String extensionOf(final String filename) {
         if (filename != null && filename.contains(".")) {
-            return filename.substring(filename.lastIndexOf("."));
+            return filename.substring(filename.lastIndexOf('.'));
         }
         return ".tmp";
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S3027 - String function use should be optimized for single characters.
You can find more information about the issue here:
An indexOf or lastIndexOf call with a single letter String can be made more performant by switching to a call with a char argument.

`Noncompliant Code Example`

`String myStr = "Hello World";`
`// ...`
`int pos = myStr.indexOf("W");  // Noncompliant`
`// ...`
`int otherPos = myStr.lastIndexOf("r"); // Noncompliant`
`// ...`
`Compliant Solution`

`String myStr = "Hello World";`
`// ...`
`int pos = myStr.indexOf('W'); `
`// ...`
`int otherPos = myStr.lastIndexOf('r');`
`// ...`
Please let me know if you have any questions.
George Kankava