### PR TITLE
squid:S2864 - 'entrySet()' should be iterated when both the key and value are needed

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/checker/CheckerFactory.java
+++ b/src/main/java/org/infernus/idea/checkstyle/checker/CheckerFactory.java
@@ -241,9 +241,9 @@ public class CheckerFactory {
         if (resolver != null && resolver instanceof ListPropertyResolver) {
             final ListPropertyResolver listResolver = (ListPropertyResolver) resolver;
             final Map<String, String> propertiesToValues = listResolver.getPropertyNamesToValues();
-            for (final String propertyName : propertiesToValues.keySet()) {
-                final String propertyValue = propertiesToValues.get(propertyName);
-                LOG.debug("- Property: " + propertyName + "=" + propertyValue);
+            for (final Map.Entry<String, String> propertyEntry : propertiesToValues.entrySet()) {
+                final String propertyValue = propertyEntry.getValue();
+                LOG.debug("- Property: " + propertyEntry.getKey() + "=" + propertyValue);
             }
         }
     }

--- a/src/main/java/org/infernus/idea/checkstyle/checker/ListPropertyResolver.java
+++ b/src/main/java/org/infernus/idea/checkstyle/checker/ListPropertyResolver.java
@@ -49,8 +49,8 @@ class ListPropertyResolver implements PropertyResolver {
             return;
         }
 
-        for (final String propertyName : properties.keySet()) {
-            setProperty(propertyName, properties.get(propertyName));
+        for (final Map.Entry<String, String> propertieEntry : properties.entrySet()) {
+            setProperty(propertieEntry.getKey(), propertieEntry.getValue());
         }
     }
 }

--- a/src/main/java/org/infernus/idea/checkstyle/toolwindow/CheckStyleToolWindowPanel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/toolwindow/CheckStyleToolWindowPanel.java
@@ -501,10 +501,10 @@ public class CheckStyleToolWindowPanel extends JPanel implements ConfigurationLi
         if (error.getCause() != null
                 && error.getCause() instanceof CheckstyleException) {
 
-            for (final Pattern errorPattern
-                    : CHECKSTYLE_ERROR_PATTERNS.keySet()) {
+            for (final Map.Entry<Pattern, String> errorPatternEntry
+                    : CHECKSTYLE_ERROR_PATTERNS.entrySet()) {
                 final Matcher errorMatcher
-                        = errorPattern.matcher(error.getCause().getMessage());
+                        = errorPatternEntry.getKey().matcher(error.getCause().getMessage());
                 if (errorMatcher.find()) {
                     final Object[] args = new Object[errorMatcher.groupCount()];
 
@@ -512,7 +512,7 @@ public class CheckStyleToolWindowPanel extends JPanel implements ConfigurationLi
                         args[i] = errorMatcher.group(i + 1);
                     }
 
-                    errorText = CheckStyleBundle.message(CHECKSTYLE_ERROR_PATTERNS.get(errorPattern), args);
+                    errorText = CheckStyleBundle.message(errorPatternEntry.getValue(), args);
                 }
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2864 - 'entrySet()' should be iterated when both the key and value are needed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
George Kankava