### PR TITLE
squid:S1301 - 'switch' statements should have at least 3 'case' clauses

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/ui/LocationTableModel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/ui/LocationTableModel.java
@@ -154,12 +154,10 @@ public class LocationTableModel extends AbstractTableModel {
 
     @Override
     public Class<?> getColumnClass(final int columnIndex) {
-        switch (columnIndex) {
-            case COLUMN_ACTIVE:
-                return Boolean.class;
-
-            default:
-                return String.class;
+        if (columnIndex == COLUMN_ACTIVE) {
+            return Boolean.class;
+        } else {
+            return String.class;
         }
     }
 
@@ -176,14 +174,10 @@ public class LocationTableModel extends AbstractTableModel {
     @Override
     public void setValueAt(final Object aValue, final int rowIndex, final int columnIndex) {
         final ConfigurationLocation rowLocation = locations.get(rowIndex);
-
-        switch (columnIndex) {
-            case COLUMN_ACTIVE:
-                updateActiveLocation(rowLocation, rowIndex, true);
-                break;
-
-            default:
-                throw new IllegalArgumentException("Column is not editable: " + columnIndex);
+        if (columnIndex == COLUMN_ACTIVE) {
+            updateActiveLocation(rowLocation, rowIndex, true);
+        } else {
+            throw new IllegalArgumentException("Column is not editable: " + columnIndex);
         }
     }
 

--- a/src/main/java/org/infernus/idea/checkstyle/ui/PropertiesTableModel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/ui/PropertiesTableModel.java
@@ -95,14 +95,11 @@ public class PropertiesTableModel extends AbstractTableModel {
     @Override
     public void setValueAt(final Object aValue, final int rowIndex,
                            final int columnIndex) {
-        switch (columnIndex) {
-            case COLUMN_VALUE:
-                final String propertyName = orderedNames.get(rowIndex);
-                properties.put(propertyName, aValue != null
-                        ? aValue.toString() : null);
-                break;
-
-            default:
+        if (columnIndex == COLUMN_VALUE) {
+            final String propertyName = orderedNames.get(rowIndex);
+            properties.put(propertyName, aValue != null
+                    ? aValue.toString() : null);
+        } else {
                 throw new IllegalArgumentException("Invalid column: "
                         + columnIndex);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1301 - 'switch' statements should have at least 3 'case' clauses.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1301
Please let me know if you have any questions.
George Kankava