### PR TITLE
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/CheckStyleConfiguration.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckStyleConfiguration.java
@@ -460,7 +460,7 @@ public final class CheckStyleConfiguration implements ExportableComponent,
      * Wrapper class for IDEA state serialisation.
      */
     public static class ProjectSettings {
-        public Map<String, String> configuration;
+        private Map<String, String> configuration;
 
         public ProjectSettings() {
             this.configuration = new TreeMap<>();

--- a/src/main/java/org/infernus/idea/checkstyle/CheckStyleModuleConfiguration.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckStyleModuleConfiguration.java
@@ -142,7 +142,7 @@ public final class CheckStyleModuleConfiguration extends Properties
      * Wrapper class for IDEA state serialisation.
      */
     public static class ModuleSettings {
-        public Map<String, String> configuration = new HashMap<>();
+        private Map<String, String> configuration = new HashMap<>();
 
         public ModuleSettings() {
             this.configuration = new HashMap<>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
Please let me know if you have any questions.
George Kankava