### PR TITLE
squid:S1192 - String literals should not be duplicated.

### DIFF
--- a/src/test/java/org/infernus/idea/checkstyle/checker/ConfigurationsTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/checker/ConfigurationsTest.java
@@ -31,6 +31,17 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class ConfigurationsTest {
 
+    private static final String A_FILE_TO_RESOLVE = "aFileToResolve";
+    private static final String A_RESOLVED_FILE = "aResolvedFile";
+    private static final String TRIGGERS_AN_IO_EXCEPTION = "triggersAnIoException";
+    private static final String TREE_WALKER = "TreeWalker";
+    private static final String PROPERTY = "property";
+    private static final String TAB_WIDTH = "tabWidth";
+    private static final String SUPPRESSION_FILTER = "SuppressionFilter";
+    private static final String IMPORT_CONTROL = "ImportControl";
+    private static final String AN_UNRESOLVABLE_FILE = "anUnresolvableFile";
+    private static final String REGEXP_HEADER = "RegexpHeader";
+    private static final String HEADER_FILE = "headerFile";
     @Mock
     private ConfigurationLocation configurationLocation;
     @Mock
@@ -44,9 +55,9 @@ public class ConfigurationsTest {
     public void setUp() throws IOException {
         interceptApplicationNotifications();
 
-        when(configurationLocation.resolveAssociatedFile("aFileToResolve", module))
-                .thenReturn("aResolvedFile");
-        when(configurationLocation.resolveAssociatedFile("triggersAnIoException", module))
+        when(configurationLocation.resolveAssociatedFile(A_FILE_TO_RESOLVE, module))
+                .thenReturn(A_RESOLVED_FILE);
+        when(configurationLocation.resolveAssociatedFile(TRIGGERS_AN_IO_EXCEPTION, module))
                 .thenThrow(new IOException("aTriggeredIoException"));
 
         underTest = new Configurations(configurationLocation, module);
@@ -73,9 +84,9 @@ public class ConfigurationsTest {
     public void tabWidthPropertyValueIsReturnedWhenPresent() {
         assertThat(
                 underTest.tabWidth(checker()
-                        .withChild(config("TreeWalker")
-                                .withChild(config("property")
-                                        .withAttribute("name", "tabWidth")
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(PROPERTY)
+                                        .withAttribute("name", TAB_WIDTH)
                                         .withAttribute("value", "7")))
                         .build()),
                 is(equalTo(7)));
@@ -85,9 +96,9 @@ public class ConfigurationsTest {
     public void aTabWidthPropertyWithANonIntegerValueReturnsTheDefault() {
         assertThat(
                 underTest.tabWidth(checker()
-                        .withChild(config("TreeWalker")
-                                .withChild(config("property")
-                                        .withAttribute("name", "tabWidth")
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(PROPERTY)
+                                        .withAttribute("name", TAB_WIDTH)
                                         .withAttribute("value", "dd")))
                         .build()),
                 is(equalTo(8)));
@@ -97,9 +108,9 @@ public class ConfigurationsTest {
     public void aTabWidthPropertyWithNoValueReturnsTheDefault() {
         assertThat(
                 underTest.tabWidth(checker()
-                        .withChild(config("TreeWalker")
-                                .withChild(config("property")
-                                        .withAttribute("name", "tabWidth")))
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(PROPERTY)
+                                        .withAttribute("name", TAB_WIDTH)))
                         .build()),
                 is(equalTo(8)));
     }
@@ -117,13 +128,13 @@ public class ConfigurationsTest {
     public void childrenOfUpdatedElementsArePreserved() throws CheckstyleException {
         assertThat(
                 underTest.resolveFilePaths(checker()
-                        .withChild(config("SuppressionFilter")
-                                .withAttribute("file", "aFileToResolve")
+                        .withChild(config(SUPPRESSION_FILTER)
+                                .withAttribute("file", A_FILE_TO_RESOLVE)
                                 .withChild(config("aChildModule")))
                         .build()),
                 is(configEqualTo(checker()
-                        .withChild(config("SuppressionFilter")
-                                .withAttribute("file", "aResolvedFile")
+                        .withChild(config(SUPPRESSION_FILTER)
+                                .withAttribute("file", A_RESOLVED_FILE)
                                 .withChild(config("aChildModule")))
                         .build())));
     }
@@ -132,15 +143,15 @@ public class ConfigurationsTest {
     public void attributesOfUpdatedElementsArePreserved() throws CheckstyleException {
         assertThat(
                 underTest.resolveFilePaths(checker()
-                        .withChild(config("TreeWalker")
-                                .withChild(config("ImportControl")
-                                        .withAttribute("file", "aFileToResolve")
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(IMPORT_CONTROL)
+                                        .withAttribute("file", A_FILE_TO_RESOLVE)
                                         .withAttribute("anotherAttribute", "anotherValue")))
                         .build()),
                 is(configEqualTo(checker()
-                        .withChild(config("TreeWalker")
-                                .withChild(config("ImportControl")
-                                        .withAttribute("file", "aResolvedFile")
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(IMPORT_CONTROL)
+                                        .withAttribute("file", A_RESOLVED_FILE)
                                         .withAttribute("anotherAttribute", "anotherValue")))
                         .build())));
     }
@@ -149,14 +160,14 @@ public class ConfigurationsTest {
     public void messagesOfUpdatedElementsArePreserved() throws CheckstyleException {
         assertThat(
                 underTest.resolveFilePaths(checker()
-                        .withChild(config("SuppressionFilter")
-                                .withAttribute("file", "aFileToResolve")
+                        .withChild(config(SUPPRESSION_FILTER)
+                                .withAttribute("file", A_FILE_TO_RESOLVE)
                                 .withMessage("messageKey", "messageValue")
                                 .withMessage("anotherMessageKey", "anotherMessageValue"))
                         .build()),
                 is(configEqualTo(checker()
-                        .withChild(config("SuppressionFilter")
-                                .withAttribute("file", "aResolvedFile")
+                        .withChild(config(SUPPRESSION_FILTER)
+                                .withAttribute("file", A_RESOLVED_FILE)
                                 .withMessage("messageKey", "messageValue")
                                 .withMessage("anotherMessageKey", "anotherMessageValue"))
                         .build())));
@@ -166,20 +177,20 @@ public class ConfigurationsTest {
     public void multipleElementsAreUpdated() throws CheckstyleException {
         assertThat(
                 underTest.resolveFilePaths(checker()
-                        .withChild(config("SuppressionFilter")
-                                .withAttribute("file", "aFileToResolve"))
-                        .withChild(config("TreeWalker")
-                                .withChild(config("ImportControl")
-                                        .withAttribute("file", "anUnresolvableFile"))
-                                .withChild(config("RegexpHeader")
-                                        .withAttribute("headerFile", "aFileToResolve")))
+                        .withChild(config(SUPPRESSION_FILTER)
+                                .withAttribute("file", A_FILE_TO_RESOLVE))
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(IMPORT_CONTROL)
+                                        .withAttribute("file", AN_UNRESOLVABLE_FILE))
+                                .withChild(config(REGEXP_HEADER)
+                                        .withAttribute(HEADER_FILE, A_FILE_TO_RESOLVE)))
                         .build()),
                 is(configEqualTo(checker()
-                        .withChild(config("SuppressionFilter")
-                                .withAttribute("file", "aResolvedFile"))
-                        .withChild(config("TreeWalker")
-                                .withChild(config("RegexpHeader")
-                                        .withAttribute("headerFile", "aResolvedFile")))
+                        .withChild(config(SUPPRESSION_FILTER)
+                                .withAttribute("file", A_RESOLVED_FILE))
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(REGEXP_HEADER)
+                                        .withAttribute(HEADER_FILE, A_RESOLVED_FILE)))
                         .build())));
     }
 
@@ -187,15 +198,15 @@ public class ConfigurationsTest {
     public void removalOfElementsDoesNotEffectOtherElements() throws CheckstyleException {
         assertThat(
                 underTest.resolveFilePaths(checker()
-                        .withChild(config("SuppressionFilter")
-                                .withAttribute("file", "anUnresolvableFile"))
-                        .withChild(config("TreeWalker")
-                                .withChild(config("RegexpHeader")
-                                        .withAttribute("headerFile", "anUnresolvableFile"))
+                        .withChild(config(SUPPRESSION_FILTER)
+                                .withAttribute("file", AN_UNRESOLVABLE_FILE))
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(REGEXP_HEADER)
+                                        .withAttribute(HEADER_FILE, AN_UNRESOLVABLE_FILE))
                                 .withChild(config("ConstantName")))
                         .build()),
                 is(configEqualTo(checker()
-                        .withChild(config("TreeWalker")
+                        .withChild(config(TREE_WALKER)
                                 .withChild(config("ConstantName")))
                         .build())));
     }
@@ -204,20 +215,20 @@ public class ConfigurationsTest {
     public void aModuleWithAFilenameThatRaisesAnIOExceptionOnResolutionDoesNotModifyTheConfiguration() throws CheckstyleException {
         assertThat(
                 underTest.resolveFilePaths(checker()
-                        .withChild(config("SuppressionFilter")
-                                .withAttribute("file", "triggersAnIoException"))
+                        .withChild(config(SUPPRESSION_FILTER)
+                                .withAttribute("file", TRIGGERS_AN_IO_EXCEPTION))
                         .build()),
                 is(configEqualTo(checker()
-                        .withChild(config("SuppressionFilter")
-                                .withAttribute("file", "triggersAnIoException"))
+                        .withChild(config(SUPPRESSION_FILTER)
+                                .withAttribute("file", TRIGGERS_AN_IO_EXCEPTION))
                         .build())));
     }
 
     @Test
     public void aModuleWithAFilenameThatRaisesAnIOExceptionOnResolutionTriggersAnErrorNotification() throws CheckstyleException {
         underTest.resolveFilePaths(checker()
-                .withChild(config("SuppressionFilter")
-                        .withAttribute("file", "triggersAnIoException"))
+                .withChild(config(SUPPRESSION_FILTER)
+                        .withAttribute("file", TRIGGERS_AN_IO_EXCEPTION))
                 .build());
 
         final Notification notification = sentNotification();
@@ -230,9 +241,9 @@ public class ConfigurationsTest {
     @Test
     public void aModuleWithAFilenameThatIsNotResolvesTriggersAWarningNotification() throws CheckstyleException {
         underTest.resolveFilePaths(checker()
-                .withChild(config("TreeWalker")
-                        .withChild(config("RegexpHeader")
-                                .withAttribute("headerFile", "anUnresolvableFile")))
+                .withChild(config(TREE_WALKER)
+                        .withChild(config(REGEXP_HEADER)
+                                .withAttribute(HEADER_FILE, AN_UNRESOLVABLE_FILE)))
                 .build());
 
         final Notification notification = sentNotification();
@@ -245,8 +256,8 @@ public class ConfigurationsTest {
     @Test
     public void aModuleWithAFilenameThatIsBlankDoesNotHaveResolutionAttempted() throws CheckstyleException {
         underTest.resolveFilePaths(checker()
-                .withChild(config("TreeWalker")
-                        .withChild(config("ImportControl")
+                .withChild(config(TREE_WALKER)
+                        .withChild(config(IMPORT_CONTROL)
                                 .withAttribute("file", "")))
                 .build());
 
@@ -263,12 +274,12 @@ public class ConfigurationsTest {
     public void aSuppressionFilterWithAResolvableFilenameHasTheModuleUpdated() throws CheckstyleException {
         assertThat(
                 underTest.resolveFilePaths(checker()
-                        .withChild(config("SuppressionFilter")
-                                .withAttribute("file", "aFileToResolve"))
+                        .withChild(config(SUPPRESSION_FILTER)
+                                .withAttribute("file", A_FILE_TO_RESOLVE))
                         .build()),
                 is(configEqualTo(checker()
-                        .withChild(config("SuppressionFilter")
-                                .withAttribute("file", "aResolvedFile"))
+                        .withChild(config(SUPPRESSION_FILTER)
+                                .withAttribute("file", A_RESOLVED_FILE))
                         .build())));
     }
 
@@ -276,8 +287,8 @@ public class ConfigurationsTest {
     public void aSuppressionFilterWithAnUnresolvableFilenameHasTheModuleRemoved() throws CheckstyleException {
         assertThat(
                 underTest.resolveFilePaths(checker()
-                        .withChild(config("SuppressionFilter")
-                                .withAttribute("file", "anUnresolvableFile"))
+                        .withChild(config(SUPPRESSION_FILTER)
+                                .withAttribute("file", AN_UNRESOLVABLE_FILE))
                         .build()),
                 is(configEqualTo(checker().build())));
     }
@@ -286,14 +297,14 @@ public class ConfigurationsTest {
     public void aRegexpHeaderWithAResolvableFilenameHasTheModuleUpdated() throws CheckstyleException {
         assertThat(
                 underTest.resolveFilePaths(checker()
-                        .withChild(config("TreeWalker")
-                                .withChild(config("RegexpHeader")
-                                        .withAttribute("headerFile", "aFileToResolve")))
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(REGEXP_HEADER)
+                                        .withAttribute(HEADER_FILE, A_FILE_TO_RESOLVE)))
                         .build()),
                 is(configEqualTo(checker()
-                        .withChild(config("TreeWalker")
-                                .withChild(config("RegexpHeader")
-                                        .withAttribute("headerFile", "aResolvedFile")))
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(REGEXP_HEADER)
+                                        .withAttribute(HEADER_FILE, A_RESOLVED_FILE)))
                         .build())));
     }
 
@@ -301,12 +312,12 @@ public class ConfigurationsTest {
     public void aRegexpHeaderWithAnUnresolvableFilenameHasTheModuleReferenceRemoved() throws CheckstyleException {
         assertThat(
                 underTest.resolveFilePaths(checker()
-                        .withChild(config("TreeWalker")
-                                .withChild(config("RegexpHeader")
-                                        .withAttribute("headerFile", "anUnresolvableFile")))
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(REGEXP_HEADER)
+                                        .withAttribute(HEADER_FILE, AN_UNRESOLVABLE_FILE)))
                         .build()),
                 is(configEqualTo(checker()
-                        .withChild(config("TreeWalker"))
+                        .withChild(config(TREE_WALKER))
                         .build())));
     }
 
@@ -314,14 +325,14 @@ public class ConfigurationsTest {
     public void aImportControlWithAResolvableFilenameHasTheModuleUpdated() throws CheckstyleException {
         assertThat(
                 underTest.resolveFilePaths(checker()
-                        .withChild(config("TreeWalker")
-                                .withChild(config("ImportControl")
-                                        .withAttribute("file", "aFileToResolve")))
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(IMPORT_CONTROL)
+                                        .withAttribute("file", A_FILE_TO_RESOLVE)))
                         .build()),
                 is(configEqualTo(checker()
-                        .withChild(config("TreeWalker")
-                                .withChild(config("ImportControl")
-                                        .withAttribute("file", "aResolvedFile")))
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(IMPORT_CONTROL)
+                                        .withAttribute("file", A_RESOLVED_FILE)))
                         .build())));
     }
 
@@ -329,12 +340,12 @@ public class ConfigurationsTest {
     public void anImportControlWithAnUnresolvableFilenameHasTheModuleReferenceRemoved() throws CheckstyleException {
         assertThat(
                 underTest.resolveFilePaths(checker()
-                        .withChild(config("TreeWalker")
-                                .withChild(config("ImportControl")
-                                        .withAttribute("file", "anUnresolvableFile")))
+                        .withChild(config(TREE_WALKER)
+                                .withChild(config(IMPORT_CONTROL)
+                                        .withAttribute("file", AN_UNRESOLVABLE_FILE)))
                         .build()),
                 is(configEqualTo(checker()
-                        .withChild(config("TreeWalker"))
+                        .withChild(config(TREE_WALKER))
                         .build())));
     }
 

--- a/src/test/java/org/infernus/idea/checkstyle/exception/CheckStylePluginExceptionTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/exception/CheckStylePluginExceptionTest.java
@@ -13,59 +13,61 @@ import static org.junit.Assert.assertThat;
 
 public class CheckStylePluginExceptionTest {
 
+    private static final String A_TEST_EXCEPTION = "aTestException";
+
     @Test
     public void anExceptionThatIsNotACheckstyleExceptionIsWrappedInAPluginException() {
         assertThat(
-                wrap(new NullPointerException("aTestException")),
+                wrap(new NullPointerException(A_TEST_EXCEPTION)),
                 is(instanceOf(CheckStylePluginException.class)));
     }
 
     @Test
     public void aCheckstyleExceptionThatHasACauseOfARecognitionExceptionIsWrappedInAPluginParseException() {
         assertThat(
-                wrap(new CheckstyleException("aTestException", new RecognitionException("aTestException"))),
+                wrap(new CheckstyleException(A_TEST_EXCEPTION, new RecognitionException(A_TEST_EXCEPTION))),
                 is(instanceOf(CheckStylePluginParseException.class)));
     }
 
     @Test
     public void aCheckstyleExceptionThatHasACauseOfASubclassOfRecognitionExceptionIsWrappedInAPluginParseException() {
         assertThat(
-                wrap(new CheckstyleException("aTestException", new MismatchedTokenException())),
+                wrap(new CheckstyleException(A_TEST_EXCEPTION, new MismatchedTokenException())),
                 is(instanceOf(CheckStylePluginParseException.class)));
     }
 
     @Test
     public void aCheckstyleExceptionThatHasACauseOfATokenStreamExceptionIsWrappedInAPluginParseException() {
         assertThat(
-                wrap(new CheckstyleException("aTestException", new TokenStreamException("aTestException"))),
+                wrap(new CheckstyleException(A_TEST_EXCEPTION, new TokenStreamException(A_TEST_EXCEPTION))),
                 is(instanceOf(CheckStylePluginParseException.class)));
     }
 
     @Test
     public void aCheckstyleExceptionThatHasACauseOfANullPointerExceptionIsWrappedInAPluginParseException() {
         assertThat(
-                wrap(new CheckstyleException("aTestException", new NullPointerException("aTestException"))),
+                wrap(new CheckstyleException(A_TEST_EXCEPTION, new NullPointerException(A_TEST_EXCEPTION))),
                 is(instanceOf(CheckStylePluginParseException.class)));
     }
 
     @Test
     public void aCheckstyleExceptionThatHasACauseOfAnArrayIndexOutOfBoundsExceptionIsWrappedInAPluginParseException() {
         assertThat(
-                wrap(new CheckstyleException("aTestException", new ArrayIndexOutOfBoundsException("aTestException"))),
+                wrap(new CheckstyleException(A_TEST_EXCEPTION, new ArrayIndexOutOfBoundsException(A_TEST_EXCEPTION))),
                 is(instanceOf(CheckStylePluginParseException.class)));
     }
 
     @Test
     public void aCheckstyleExceptionThatHasACauseOfAnIllegalStateExceptionIsWrappedInAPluginParseException() {
         assertThat(
-                wrap(new CheckstyleException("aTestException", new IllegalStateException("aTestException"))),
+                wrap(new CheckstyleException(A_TEST_EXCEPTION, new IllegalStateException(A_TEST_EXCEPTION))),
                 is(instanceOf(CheckStylePluginParseException.class)));
     }
 
     @Test
     public void aCheckstyleExceptionThatHasACauseOfAnyOtherExceptionIsWrappedInAPluginException() {
         assertThat(
-                wrap(new CheckstyleException("aTestException", new IllegalStateException("aTestException"))),
+                wrap(new CheckstyleException(A_TEST_EXCEPTION, new IllegalStateException(A_TEST_EXCEPTION))),
                 is(instanceOf(CheckStylePluginException.class)));
     }
 

--- a/src/test/java/org/infernus/idea/checkstyle/importer/CodeStyleImporterTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/importer/CodeStyleImporterTest.java
@@ -31,8 +31,9 @@ public class CodeStyleImporterTest extends LightPlatformTestCase {
             "          \"-//Puppy Crawl//DTD Check Configuration 1.3//EN\"\n" +
             "          \"http://www.puppycrawl.com/dtds/configuration_1_3.dtd\">\n" +
             "<module name = \"Checker\">\n";
+    private static final String MODULE = "</module>";
     private final static String FILE_SUFFIX =
-            "</module>";
+            MODULE;
     
     private void importConfiguration(@NotNull String configuration) throws Exception {
         configuration = FILE_PREFIX + configuration + FILE_SUFFIX;
@@ -40,7 +41,7 @@ public class CodeStyleImporterTest extends LightPlatformTestCase {
     }
     
     private String inTreeWalker(@NotNull String configuration) {
-        return "<module name=\"TreeWalker\">" + configuration + "</module>";
+        return "<module name=\"TreeWalker\">" + configuration + MODULE;
     }
     
     private Configuration loadConfiguration(@NotNull String configuration) throws CheckstyleException {
@@ -53,7 +54,7 @@ public class CodeStyleImporterTest extends LightPlatformTestCase {
                 inTreeWalker(
                         "<module name=\"LineLength\">\n" +
                         "    <property name=\"max\" value=\"100\"/>\n" +
-                        "</module>"
+                                MODULE
                 )
         );
         assertEquals(100, javaSettings.RIGHT_MARGIN);
@@ -66,7 +67,7 @@ public class CodeStyleImporterTest extends LightPlatformTestCase {
                 inTreeWalker(
                         "<module name=\"EmptyLineSeparator\">\n" +
                         "    <property name=\"tokens\" value=\"VARIABLE_DEF, METHOD_DEF\"/>\n" +
-                        "</module>"
+                                MODULE
                 )
         );
         assertEquals(1, javaSettings.BLANK_LINES_AROUND_FIELD);
@@ -86,7 +87,7 @@ public class CodeStyleImporterTest extends LightPlatformTestCase {
                         "<module name=\"FileTabCharacter\">\n" +
                         "    <property name=\"eachLine\" value=\"true\" />\n" +
                         "    <property name=\"fileExtensions\" value=\"java,xml\" />\n" +
-                        "</module>"
+                                MODULE
                 )
         );
         assertFalse(javaIndentOptions.USE_TAB_CHARACTER);
@@ -118,7 +119,7 @@ public class CodeStyleImporterTest extends LightPlatformTestCase {
                 inTreeWalker(
                         "<module name=\"WhitespaceAfter\">\n" +
                         "    <property name=\"tokens\" value=\"COMMA, SEMI\"/>\n" +
-                        "</module>"
+                                MODULE
                 )
         );
         assertTrue(javaSettings.SPACE_AFTER_COMMA);
@@ -135,7 +136,7 @@ public class CodeStyleImporterTest extends LightPlatformTestCase {
                         "<module name=\"WhitespaceAround\">\n" +
                         "    <property name=\"tokens\" value=\"ASSIGN\"/>\n" +
                         "    <property name=\"tokens\" value=\"EQUAL\"/>\n" +
-                        "</module>"
+                                MODULE
                 )
         );
         assertTrue(javaSettings.SPACE_AROUND_ASSIGNMENT_OPERATORS);
@@ -168,7 +169,7 @@ public class CodeStyleImporterTest extends LightPlatformTestCase {
                         "<module name=\"LeftCurly\">\n" +
                         "    <property name=\"option\" value=\"eol\"/>\n" +
                         "    <property name=\"tokens\" value=\"METHOD_DEF,LITERAL_IF\"/>\n" +
-                        "</module>"
+                                MODULE
                 )
         );
         assertEquals(CommonCodeStyleSettings.NEXT_LINE, javaSettings.CLASS_BRACE_STYLE);
@@ -184,7 +185,7 @@ public class CodeStyleImporterTest extends LightPlatformTestCase {
                 inTreeWalker(
                         "<module name=\"NeedBraces\">\n" +
                         "    <property name=\"allowSingleLineStatement\" value=\"true\"/>\n" +
-                        "</module>"
+                                MODULE
                 )
         );
         assertEquals(CommonCodeStyleSettings.FORCE_BRACES_IF_MULTILINE, javaSettings.DOWHILE_BRACE_FORCE);
@@ -207,7 +208,7 @@ public class CodeStyleImporterTest extends LightPlatformTestCase {
                         "            <property name=\"throwsIndent\" value=\"4\"/>\n" +
                         "            <property name=\"lineWrappingIndentation\" value=\"4\"/>\n" +
                         "            <property name=\"arrayInitIndent\" value=\"2\"/>\n" +
-                        "</module>"
+                                MODULE
                 )
         );
         javaSettings.INDENT_BREAK_FROM_CASE = true;

--- a/src/test/java/org/infernus/idea/checkstyle/model/ConfigurationLocationTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/model/ConfigurationLocationTest.java
@@ -35,6 +35,11 @@ public class ConfigurationLocationTest {
             "  <property name=\"something\" value=\"${property-four}\"/>\n" +
             "</module>\n" +
             "</module>";
+    private static final String PROPERTY_ONE = "property-one";
+    private static final String PROPERTY_TWO = "property-two";
+    private static final String A_VALUE = "aValue";
+    private static final String A_NEW_DESCRIPTION = "aNewDescription";
+    private static final String A_LOCATION = "aLocation";
 
     private TestConfigurationLocation underTest;
 
@@ -48,8 +53,8 @@ public class ConfigurationLocationTest {
     public void whenReadPropertiesAreExtracted() throws IOException {
         underTest.resolve();
 
-        assertThat(underTest.getProperties(), hasEntry("property-one", ""));
-        assertThat(underTest.getProperties(), hasEntry("property-two", ""));
+        assertThat(underTest.getProperties(), hasEntry(PROPERTY_ONE, ""));
+        assertThat(underTest.getProperties(), hasEntry(PROPERTY_TWO, ""));
         assertThat(underTest.getProperties(), hasEntry("property-three", ""));
     }
 
@@ -60,8 +65,8 @@ public class ConfigurationLocationTest {
         underTest.setLocation(TEST_FILE_2);
         underTest.resolve();
 
-        assertThat(underTest.getProperties(), hasEntry("property-one", ""));
-        assertThat(underTest.getProperties(), hasEntry("property-two", ""));
+        assertThat(underTest.getProperties(), hasEntry(PROPERTY_ONE, ""));
+        assertThat(underTest.getProperties(), hasEntry(PROPERTY_TWO, ""));
         assertThat(underTest.getProperties(), hasEntry("property-four", ""));
         assertThat(underTest.getProperties(), not(hasKey("property-three")));
     }
@@ -70,27 +75,27 @@ public class ConfigurationLocationTest {
     public void propertyValuesAreRetainedWhenThePropertiesAreReread() throws IOException {
         underTest.resolve();
 
-        updatePropertyOn(underTest, "property-two", "aValue");
+        updatePropertyOn(underTest, PROPERTY_TWO, A_VALUE);
 
         underTest.setLocation(TEST_FILE_2);
         underTest.resolve();
 
-        assertThat(underTest.getProperties(), hasEntry("property-two", "aValue"));
+        assertThat(underTest.getProperties(), hasEntry(PROPERTY_TWO, A_VALUE));
     }
 
     @Test
     public void theDescriptionIsSetToThePassedStringWhenNotNull() {
-        underTest.setDescription("aNewDescription");
+        underTest.setDescription(A_NEW_DESCRIPTION);
 
-        assertThat(underTest.getDescription(), is(equalTo("aNewDescription")));
+        assertThat(underTest.getDescription(), is(equalTo(A_NEW_DESCRIPTION)));
     }
 
     @Test
     public void theDescriptionDefaultsToTheLocationWhenANullValueIsGiven() {
-        underTest.setLocation("aLocation");
+        underTest.setLocation(A_LOCATION);
         underTest.setDescription(null);
 
-        assertThat(underTest.getDescription(), is(equalTo("aLocation")));
+        assertThat(underTest.getDescription(), is(equalTo(A_LOCATION)));
     }
 
     @Test
@@ -116,7 +121,7 @@ public class ConfigurationLocationTest {
         final TestConfigurationLocation location1 = new TestConfigurationLocation(TEST_FILE);
         final TestConfigurationLocation location2 = new TestConfigurationLocation(TEST_FILE);
 
-        location1.setDescription("aNewDescription");
+        location1.setDescription(A_NEW_DESCRIPTION);
 
         assertThat(location1.hasChangedFrom(location2), is(true));
     }
@@ -126,7 +131,7 @@ public class ConfigurationLocationTest {
         final TestConfigurationLocation location1 = new TestConfigurationLocation(TEST_FILE);
         final TestConfigurationLocation location2 = new TestConfigurationLocation(TEST_FILE);
 
-        updatePropertyOn(location1, "property-two", "aValue");
+        updatePropertyOn(location1, PROPERTY_TWO, A_VALUE);
 
         assertThat(location1.hasChangedFrom(location2), is(true));
     }
@@ -149,7 +154,7 @@ public class ConfigurationLocationTest {
 
     @Test
     public void aDescriptorContainsTheLocationDescriptionAndType() {
-        final ConfigurationLocation location = new TestConfigurationLocation("aLocation");
+        final ConfigurationLocation location = new TestConfigurationLocation(A_LOCATION);
 
         assertThat(location.getDescriptor(), is(equalTo(format("%s:%s:%s",
                 location.getType(), location.getLocation(), location.getDescription()))));
@@ -158,10 +163,10 @@ public class ConfigurationLocationTest {
     @Test
     public void equalsIgnoresProperties() throws IOException {
         final TestConfigurationLocation location1 = new TestConfigurationLocation(TEST_FILE);
-        updatePropertyOn(location1, "property-one", "aValue");
+        updatePropertyOn(location1, PROPERTY_ONE, A_VALUE);
 
         final TestConfigurationLocation location2 = new TestConfigurationLocation(TEST_FILE);
-        updatePropertyOn(location2, "property-one", "anotherValue");
+        updatePropertyOn(location2, PROPERTY_ONE, "anotherValue");
 
         assertThat(location1, is(equalTo(location2)));
     }
@@ -169,10 +174,10 @@ public class ConfigurationLocationTest {
     @Test
     public void hashCodeIgnoresProperties() throws IOException {
         final TestConfigurationLocation location1 = new TestConfigurationLocation(TEST_FILE);
-        updatePropertyOn(location1, "property-one", "aValue");
+        updatePropertyOn(location1, PROPERTY_ONE, A_VALUE);
 
         final TestConfigurationLocation location2 = new TestConfigurationLocation(TEST_FILE);
-        updatePropertyOn(location2, "property-one", "anotherValue");
+        updatePropertyOn(location2, PROPERTY_ONE, "anotherValue");
 
         assertThat(location1.hashCode(), is(equalTo(location2.hashCode())));
     }

--- a/src/test/java/org/infernus/idea/checkstyle/model/FileConfigurationLocationTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/model/FileConfigurationLocationTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class FileConfigurationLocationTest {
     private static final String PROJECT_PATH = "/the/base-project/path";
+    private static final String A_PATH_TO_CHECKSTYLE_XML = "/a-path/to/checkstyle.xml";
 
     @Mock
     private Project project;
@@ -44,7 +45,7 @@ public class FileConfigurationLocationTest {
 
     @Test
     public void theProjectDirectoryShouldBeTokenisedInDescriptorForUnixPaths() {
-        underTest.setLocation(PROJECT_PATH + "/a-path/to/checkstyle.xml");
+        underTest.setLocation(PROJECT_PATH + A_PATH_TO_CHECKSTYLE_XML);
 
         assertThat(underTest.getDescriptor(), is(equalTo("LOCAL_FILE:$PRJ_DIR$/a-path/to/checkstyle.xml:aDescription")));
     }
@@ -64,9 +65,9 @@ public class FileConfigurationLocationTest {
 
     @Test
     public void aUnixLocationContainingTheProjectPathShouldBeDetokenisedCorrectly() {
-        underTest.setLocation(PROJECT_PATH + "/a-path/to/checkstyle.xml");
+        underTest.setLocation(PROJECT_PATH + A_PATH_TO_CHECKSTYLE_XML);
 
-        assertThat(underTest.getLocation(), is(equalTo(PROJECT_PATH + "/a-path/to/checkstyle.xml")));
+        assertThat(underTest.getLocation(), is(equalTo(PROJECT_PATH + A_PATH_TO_CHECKSTYLE_XML)));
     }
 
     @Test

--- a/src/test/java/org/infernus/idea/checkstyle/util/FilePathsTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/util/FilePathsTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.fail;
 
 public class FilePathsTest {
 
+    private static final String C_JAVA_WORKSPACE_ACCEPTANCE_TESTS_STANDARD_TEST_DATA_GEO = "C:\\Java\\workspace\\AcceptanceTests\\Standard test data\\geo";
+
     @Test
     public void testGetRelativePathsUnix() {
         assertEquals("stuff/xyz.dat", FilePaths.relativePath("/var/data/stuff/xyz.dat", "/var/data/", "/"));
@@ -67,16 +69,16 @@ public class FilePathsTest {
 
     @Test
     public void testTargetAndBaseAreIdentical() {
-        String target = "C:\\Java\\workspace\\AcceptanceTests\\Standard test data\\geo";
-        String base = "C:\\Java\\workspace\\AcceptanceTests\\Standard test data\\geo";
+        String target = C_JAVA_WORKSPACE_ACCEPTANCE_TESTS_STANDARD_TEST_DATA_GEO;
+        String base = C_JAVA_WORKSPACE_ACCEPTANCE_TESTS_STANDARD_TEST_DATA_GEO;
 
         assertEquals(".", FilePaths.relativePath(target, base, "\\"));
     }
 
     @Test
     public void testTargetAndBaseAreIdentical2() {
-        String target = "C:\\Java\\workspace\\AcceptanceTests\\Standard test data\\geo";
-        String base = "C:\\Java\\workspace\\AcceptanceTests\\Standard test data\\geo";
+        String target = C_JAVA_WORKSPACE_ACCEPTANCE_TESTS_STANDARD_TEST_DATA_GEO;
+        String base = C_JAVA_WORKSPACE_ACCEPTANCE_TESTS_STANDARD_TEST_DATA_GEO;
 
         assertEquals(".", FilePaths.relativePath(target, base, "\\"));
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 - String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava