### PR TITLE
squid:S2160 - Subclasses that add fields should override 'equals'

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/CheckStyleModuleConfiguration.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckStyleModuleConfiguration.java
@@ -138,6 +138,25 @@ public final class CheckStyleModuleConfiguration extends Properties
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        CheckStyleModuleConfiguration that = (CheckStyleModuleConfiguration) o;
+
+        return module != null ? module.equals(that.module) : that.module == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (module != null ? module.hashCode() : 0);
+        return result;
+    }
+
     /**
      * Wrapper class for IDEA state serialisation.
      */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2160 - Subclasses that add fields should override 'equals'.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2160
Please let me know if you have any questions.
George Kankava