### PR TITLE
Use Gradle distribution with sources

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip


### PR DESCRIPTION
A minor configuration change: Configure Gradle to use the Gradle distribution with sources. This enables us to see the Gradle sources when interested, and also gets rid of a little warning message that IDEA shows when starting up. Thanks!