### PR TITLE
Fixed tests for Windows

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/model/RelativeFileConfigurationLocation.java
+++ b/src/main/java/org/infernus/idea/checkstyle/model/RelativeFileConfigurationLocation.java
@@ -38,8 +38,8 @@ public class RelativeFileConfigurationLocation extends FileConfigurationLocation
         }
 
         try {
-            final String basePath = projectPath.getAbsolutePath() + File.separator;
-            return basePath + FilePaths.relativePath(path, basePath, File.separator);
+            final String basePath = absolutePathOf(projectPath) + separatorChar();
+            return basePath + FilePaths.relativePath(path, basePath, "" + separatorChar());
 
         } catch (FilePaths.PathResolutionException e) {
             LOG.debug("No common path was found between " + path + " and " + projectPath.getAbsolutePath());

--- a/src/test/java/org/infernus/idea/checkstyle/model/FileConfigurationLocationTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/model/FileConfigurationLocationTest.java
@@ -2,6 +2,7 @@ package org.infernus.idea.checkstyle.model;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import org.apache.commons.io.FilenameUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -126,7 +127,8 @@ public class FileConfigurationLocationTest {
             if (file.getPath().startsWith("c:")) {
                 return file.getPath().replace('/', '\\').replaceAll("\\\\\\\\", "\\\\");
             }
-            return file.getAbsolutePath();
+
+            return FilenameUtils.separatorsToUnix(file.getPath());
         }
     }
 

--- a/src/test/java/org/infernus/idea/checkstyle/model/RelativeFileConfigurationLocationTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/model/RelativeFileConfigurationLocationTest.java
@@ -2,11 +2,14 @@ package org.infernus.idea.checkstyle.model;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import org.apache.commons.io.FilenameUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.File;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -30,7 +33,7 @@ public class RelativeFileConfigurationLocationTest {
         when(projectBase.getPath()).thenReturn(PROJECT_PATH);
         when(project.getBaseDir()).thenReturn(projectBase);
 
-        underTest = new RelativeFileConfigurationLocation(project);
+        underTest = new TestFileConfigurationLocation(project, '/');
         underTest.setLocation("aLocation");
         underTest.setDescription("aDescription");
     }
@@ -61,6 +64,31 @@ public class RelativeFileConfigurationLocationTest {
         underTest.setLocation("/somewhere/else/entirely/another-project/rules.xml");
 
         assertThat(underTest.getLocation(), is(equalTo(PROJECT_PATH + "/../../../somewhere/else/entirely/another-project/rules.xml")));
+    }
+
+    private class TestFileConfigurationLocation extends RelativeFileConfigurationLocation {
+        private final char separatorChar;
+
+        TestFileConfigurationLocation(final Project project,
+                                      final char separatorChar) {
+            super(project);
+            this.separatorChar = separatorChar;
+        }
+
+        @Override
+        char separatorChar() {
+            return separatorChar;
+        }
+
+        @Override
+        String absolutePathOf(final File file) {
+            // a nasty hack to pretend we're on a Windows box when required...
+            if (file.getPath().startsWith("c:")) {
+                return file.getPath().replace('/', '\\').replaceAll("\\\\\\\\", "\\\\");
+            }
+
+            return FilenameUtils.separatorsToUnix(file.getPath());
+        }
     }
 
 }


### PR DESCRIPTION
On Windows 5 of 73 tests fail. 

> org.infernus.idea.checkstyle.model.FileConfigurationLocationTest > theProjectDirectoryShouldBeTokenisedInDescriptorForUnixPaths FAILED
>     java.lang.AssertionError at FileConfigurationLocationTest.java:49
> 
> org.infernus.idea.checkstyle.model.RelativeFileConfigurationLocationTest > aTokenisedPathWithRelativeElementsIsStoredAsProjectRelative FAILED
>     java.lang.AssertionError at RelativeFileConfigurationLocationTest.java:56
> 
> org.infernus.idea.checkstyle.model.RelativeFileConfigurationLocationTest > aPathWithNoCommonElementsIsStoredAsProjectRelative FAILED
>     java.lang.AssertionError at RelativeFileConfigurationLocationTest.java:63
> 
> org.infernus.idea.checkstyle.model.RelativeFileConfigurationLocationTest > aPathWithRelativeElementsIsStoredAsProjectRelative FAILED
>     java.lang.AssertionError at RelativeFileConfigurationLocationTest.java:49
> 
> org.infernus.idea.checkstyle.model.RelativeFileConfigurationLocationTest > anAbsolutePathIsStoredAsProjectRelative FAILED
>     java.lang.AssertionError at RelativeFileConfigurationLocationTest.java:42