### PR TITLE
Fix #286 by reading the configuration when the Checkstyle project service starts

### DIFF
--- a/src/csaccessTest/java/org/infernus/idea/checkstyle/service/ServiceLayerBasicTest.java
+++ b/src/csaccessTest/java/org/infernus/idea/checkstyle/service/ServiceLayerBasicTest.java
@@ -1,14 +1,8 @@
 package org.infernus.idea.checkstyle.service;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
+import org.infernus.idea.checkstyle.CheckStyleConfiguration;
 import org.infernus.idea.checkstyle.CheckstyleProjectService;
 import org.infernus.idea.checkstyle.checker.CheckStyleChecker;
 import org.infernus.idea.checkstyle.checker.ScannableFile;
@@ -16,12 +10,20 @@ import org.infernus.idea.checkstyle.csapi.CheckstyleActions;
 import org.infernus.idea.checkstyle.csapi.TabWidthAndBaseDirProvider;
 import org.infernus.idea.checkstyle.exception.CheckstyleToolException;
 import org.infernus.idea.checkstyle.model.ConfigurationLocation;
+import org.infernus.idea.checkstyle.model.ScanScope;
 import org.jetbrains.annotations.NotNull;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 
 public class ServiceLayerBasicTest
@@ -37,6 +39,14 @@ public class ServiceLayerBasicTest
 
     @BeforeClass
     public static void setUp() {
+        CheckStyleConfiguration mockPluginConfig = Mockito.mock(CheckStyleConfiguration.class);
+        Mockito.when(mockPluginConfig.getCheckstyleVersion(Mockito.anyString())).thenReturn(CsVersionInfo
+                .getCurrentCsVersion());
+        Mockito.when(mockPluginConfig.getThirdPartyClassPath()).thenReturn(null);
+        Mockito.when(mockPluginConfig.getProject()).thenReturn(PROJECT);
+        Mockito.when(mockPluginConfig.getScanScope()).thenReturn(ScanScope.AllSources);
+        CheckStyleConfiguration.activateMock4UnitTesting(mockPluginConfig);
+
         sCheckstyleProjectService = new CheckstyleProjectService(PROJECT);
         CheckstyleProjectService.activateMock4UnitTesting(sCheckstyleProjectService);
     }
@@ -45,6 +55,7 @@ public class ServiceLayerBasicTest
     public static void tearDown() {
         sCheckstyleProjectService = null;
         CheckstyleProjectService.activateMock4UnitTesting(null);
+        CheckStyleConfiguration.activateMock4UnitTesting(null);
     }
 
 

--- a/src/main/java/org/infernus/idea/checkstyle/CheckStyleConfigurable.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckStyleConfigurable.java
@@ -61,7 +61,7 @@ public class CheckStyleConfigurable
             boolean result = haveLocationsChanged(configuration) || hasActiveLocationChanged(configuration) ||
                     !configuration.getThirdPartyClassPath().equals(configPanel.getThirdPartyClasspath()) ||
                     configuration.getScanScope() != configPanel.getScanScope() || configuration.isSuppressingErrors()
-                    != configPanel.isSuppressingErrors() || !configuration.getCheckstyleVersion().equals(configPanel
+                    != configPanel.isSuppressingErrors() || !configuration.getCheckstyleVersion(null).equals(configPanel
                     .getCheckstyleVersion());
             if (LOG.isTraceEnabled()) {
                 LOG.trace("isModified() - exit - result=" + result);
@@ -120,7 +120,7 @@ public class CheckStyleConfigurable
     }
 
     CheckStyleConfiguration getConfiguration() {
-        return ServiceManager.getService(project, CheckStyleConfiguration.class);
+        return CheckStyleConfiguration.getInstance(project);
     }
 
     private CheckerFactoryCache getCheckerFactoryCache() {
@@ -130,7 +130,7 @@ public class CheckStyleConfigurable
     public void reset() {
         LOG.trace("reset() - enter");
         final CheckStyleConfiguration configuration = getConfiguration();
-        configPanel.setCheckstyleVersion(configuration.getCheckstyleVersion());
+        configPanel.setCheckstyleVersion(configuration.getCheckstyleVersion(null));
         configPanel.setConfigurationLocations(configuration.getAndResolveConfigurationLocations());
         configPanel.setActiveLocation(configuration.getActiveConfiguration());
         configPanel.setScanScope(configuration.getScanScope());

--- a/src/main/java/org/infernus/idea/checkstyle/CheckStyleConfiguration.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckStyleConfiguration.java
@@ -65,6 +65,10 @@ public class CheckStyleConfiguration
 
     private final Project project;
 
+    /** mock instance which may be set and used by unit tests */
+    private static CheckStyleConfiguration sMock = null;
+
+
     /**
      * Create a new configuration bean.
      *
@@ -77,6 +81,7 @@ public class CheckStyleConfiguration
 
         this.project = project;
     }
+
 
     public void addConfigurationListener(final ConfigurationListener configurationListener) {
         if (configurationListener != null) {
@@ -309,11 +314,15 @@ public class CheckStyleConfiguration
         storage.put(THIRDPARTY_CLASSPATH, valueString.toString());
     }
 
-    public String getCheckstyleVersion() {
+    public String getCheckstyleVersion(@Nullable final String defaultVersion) {
         String result = storage.get(CHECKSTYLE_VERSION_SETTING);
         if (result == null) {
-            CheckstyleProjectService csService = CheckstyleProjectService.getInstance(project);
-            result = csService.getDefaultVersion();
+            if (defaultVersion != null) {
+                result = defaultVersion;
+            } else {
+                CheckstyleProjectService csService = CheckstyleProjectService.getInstance(project);
+                result = csService.getDefaultVersion();
+            }
         }
         return result;
     }
@@ -515,5 +524,19 @@ public class CheckStyleConfiguration
             }
             return configuration;
         }
+    }
+
+
+    public static CheckStyleConfiguration getInstance(@NotNull final Project pProject) {
+        CheckStyleConfiguration result = sMock;
+        if (result == null) {
+            result = ServiceManager.getService(pProject, CheckStyleConfiguration.class);
+        }
+        return result;
+    }
+
+
+    public static void activateMock4UnitTesting(@Nullable final CheckStyleConfiguration pMock) {
+        sMock = pMock;
     }
 }

--- a/src/main/java/org/infernus/idea/checkstyle/CheckStylePlugin.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckStylePlugin.java
@@ -58,7 +58,7 @@ public final class CheckStylePlugin
      */
     public CheckStylePlugin(@NotNull final Project project) {
         this.project = project;
-        this.configuration = ServiceManager.getService(project, CheckStyleConfiguration.class);
+        this.configuration = CheckStyleConfiguration.getInstance(project);
 
         LOG.info("CheckStyle Plugin loaded with project base dir: \"" + getProjectPath() + "\"");
 

--- a/src/main/java/org/infernus/idea/checkstyle/CheckstyleProjectService.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckstyleProjectService.java
@@ -55,7 +55,9 @@ public class CheckstyleProjectService
     public CheckstyleProjectService(@NotNull final Project project) {
         this.project = project;
         supportedVersions = readSupportedVersions();
-        activateCheckstyleVersion(getDefaultVersion(), null);
+        final CheckStyleConfiguration pluginConfig = CheckStyleConfiguration.getInstance(project);
+        activateCheckstyleVersion(pluginConfig.getCheckstyleVersion(getDefaultVersion()),
+                pluginConfig.getThirdPartyClassPath());
     }
 
 

--- a/src/test/java/org/infernus/idea/checkstyle/CheckStyleConfigurableTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/CheckStyleConfigurableTest.java
@@ -32,7 +32,7 @@ public class CheckStyleConfigurableTest {
 
             CheckStyleConfiguration mockConfig = Mockito.mock(CheckStyleConfiguration.class);
             when(mockConfig.getProject()).thenReturn(mockProject);
-            when(mockConfig.getCheckstyleVersion()).thenReturn("7.1.2");
+            when(mockConfig.getCheckstyleVersion(Mockito.anyString())).thenReturn("7.1.2");
             when(mockConfig.configurationLocationFactory()).thenReturn(mockLocFactory);
             when(mockConfig.getActiveConfiguration()).thenReturn(mockLocations.get(0));
             when(mockConfig.configurationLocations()).thenReturn(mockLocations);

--- a/src/test/java/org/infernus/idea/checkstyle/CheckstyleProjectServiceTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/CheckstyleProjectServiceTest.java
@@ -1,20 +1,38 @@
 package org.infernus.idea.checkstyle;
 
-import java.util.SortedSet;
-
 import com.intellij.openapi.project.Project;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.util.SortedSet;
 
 
 public class CheckstyleProjectServiceTest
 {
+    private static final Project PROJECT = Mockito.mock(Project.class);
+
+
+    @BeforeClass
+    public static void setUp() {
+        CheckStyleConfiguration mockPluginConfig = Mockito.mock(CheckStyleConfiguration.class);
+        Mockito.when(mockPluginConfig.getCheckstyleVersion(Mockito.anyString())).thenReturn("7.1.1");
+        Mockito.when(mockPluginConfig.getThirdPartyClassPath()).thenReturn(null);
+        Mockito.when(mockPluginConfig.getProject()).thenReturn(PROJECT);
+        CheckStyleConfiguration.activateMock4UnitTesting(mockPluginConfig);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        CheckStyleConfiguration.activateMock4UnitTesting(null);
+    }
+
+
     @Test
-    public void testReadVersions()
-    {
-        Project mockProject = Mockito.mock(Project.class);
-        CheckstyleProjectService service = new CheckstyleProjectService(mockProject);
+    public void testReadVersions() {
+        CheckstyleProjectService service = new CheckstyleProjectService(PROJECT);
         SortedSet<String> versions = service.getSupportedVersions();
         Assert.assertNotNull(versions);
         Assert.assertTrue(versions.size() > 0);

--- a/src/test/java/org/infernus/idea/checkstyle/VersionMixExceptionTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/VersionMixExceptionTest.java
@@ -23,6 +23,7 @@ import org.infernus.idea.checkstyle.csapi.TabWidthAndBaseDirProvider;
 import org.infernus.idea.checkstyle.exception.CheckStylePluginException;
 import org.infernus.idea.checkstyle.exception.CheckstyleVersionMixException;
 import org.infernus.idea.checkstyle.model.ConfigurationLocation;
+import org.infernus.idea.checkstyle.model.ScanScope;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.mockito.Mockito;
@@ -46,6 +47,14 @@ public class VersionMixExceptionTest
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+
+        CheckStyleConfiguration mockPluginConfig = Mockito.mock(CheckStyleConfiguration.class);
+        Mockito.when(mockPluginConfig.getCheckstyleVersion(Mockito.anyString())).thenReturn(BASE_VERSION);
+        Mockito.when(mockPluginConfig.getThirdPartyClassPath()).thenReturn(null);
+        Mockito.when(mockPluginConfig.getProject()).thenReturn(PROJECT);
+        Mockito.when(mockPluginConfig.getScanScope()).thenReturn(ScanScope.AllSources);
+        CheckStyleConfiguration.activateMock4UnitTesting(mockPluginConfig);
+
         csService = new CheckstyleProjectService(PROJECT);
         csService.activateCheckstyleVersion(BASE_VERSION, null);
         CheckstyleProjectService.activateMock4UnitTesting(csService);
@@ -55,6 +64,7 @@ public class VersionMixExceptionTest
     protected void tearDown() throws Exception {
         try {
             CheckstyleProjectService.activateMock4UnitTesting(null);
+            CheckStyleConfiguration.activateMock4UnitTesting(null);
             csService = null;
         } finally {
             super.tearDown();

--- a/src/test/java/org/infernus/idea/checkstyle/importer/CodeStyleImporterTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/importer/CodeStyleImporterTest.java
@@ -6,8 +6,10 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import com.intellij.testFramework.LightPlatformTestCase;
+import org.infernus.idea.checkstyle.CheckStyleConfiguration;
 import org.infernus.idea.checkstyle.CheckstyleProjectService;
 import org.infernus.idea.checkstyle.csapi.CheckstyleInternalObject;
+import org.infernus.idea.checkstyle.model.ScanScope;
 import org.jetbrains.annotations.NotNull;
 import org.mockito.Mockito;
 
@@ -19,14 +21,31 @@ public class CodeStyleImporterTest
     private CommonCodeStyleSettings javaSettings;
 
     private final Project project = Mockito.mock(Project.class);
-    private final CheckstyleProjectService csService = new CheckstyleProjectService(project);
+    private CheckstyleProjectService csService = null;
 
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+
+        CheckStyleConfiguration mockPluginConfig = null;
+        mockPluginConfig = Mockito.mock(CheckStyleConfiguration.class);
+        Mockito.when(mockPluginConfig.getCheckstyleVersion(Mockito.anyString())).thenReturn("7.1.1");
+        Mockito.when(mockPluginConfig.getThirdPartyClassPath()).thenReturn(null);
+        Mockito.when(mockPluginConfig.getProject()).thenReturn(project);
+        Mockito.when(mockPluginConfig.getScanScope()).thenReturn(ScanScope.AllSources);
+        CheckStyleConfiguration.activateMock4UnitTesting(mockPluginConfig);
+
+        csService = new CheckstyleProjectService(project);
+
         codeStyleSettings = new CodeStyleSettings(false);
         javaSettings = codeStyleSettings.getCommonSettings(JavaLanguage.INSTANCE);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        CheckStyleConfiguration.activateMock4UnitTesting(null);
     }
 
     private final static String FILE_PREFIX =

--- a/src/test/java/org/infernus/idea/checkstyle/model/ConfigurationLocationFactoryTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/model/ConfigurationLocationFactoryTest.java
@@ -16,7 +16,8 @@ public class ConfigurationLocationFactoryTest {
         assertThat(
                 underTest.create(mock(Project.class), "LOCAL_FILE:/Users/aUser/Projects/aProject/checkstyle/cs-rules.xml:Some checkstyle rules"),
                 allOf(
-                        hasProperty("location", is("/Users/aUser/Projects/aProject/checkstyle/cs-rules.xml")),
+                        hasProperty("location", isOneOf("/Users/aUser/Projects/aProject/checkstyle/cs-rules.xml",
+                                "\\Users\\aUser\\Projects\\aProject\\checkstyle\\cs-rules.xml")),
                         hasProperty("description", is("Some checkstyle rules"))));
     }
 


### PR DESCRIPTION
Fixes #286, and possibly some other problems as well, because we also did not set the Checkstyle version from the configuration, but used the default version upon startup.
@jshiell It would be great if you could do the user acceptance testing again - thanks!