### PR TITLE
Provide cached checkers with a more reliable means of getting their project service

### DIFF
--- a/src/csaccess/java/org/infernus/idea/checkstyle/service/cmd/OpCreateChecker.java
+++ b/src/csaccess/java/org/infernus/idea/checkstyle/service/cmd/OpCreateChecker.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.Project;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
+import org.infernus.idea.checkstyle.CheckstyleProjectService;
 import org.infernus.idea.checkstyle.checker.CheckStyleChecker;
 import org.infernus.idea.checkstyle.csapi.TabWidthAndBaseDirProvider;
 import org.infernus.idea.checkstyle.model.ConfigurationLocation;
@@ -59,7 +60,8 @@ public class OpCreateChecker
         CheckerWithConfig cwc = new CheckerWithConfig(checker, csConfig);
         final TabWidthAndBaseDirProvider configs = configurations != null ? configurations : new Configurations
                 (module, csConfig);
-        return new CheckStyleChecker(cwc, configs.tabWidth(), configs.baseDir(), loaderOfCheckedCode);
+        return new CheckStyleChecker(cwc, configs.tabWidth(), configs.baseDir(), loaderOfCheckedCode,
+                CheckstyleProjectService.getInstance(pProject).getCheckstyleInstance());
     }
 
 

--- a/src/csaccessTest/java/org/infernus/idea/checkstyle/service/cmd/OpCreateCheckerTest.java
+++ b/src/csaccessTest/java/org/infernus/idea/checkstyle/service/cmd/OpCreateCheckerTest.java
@@ -2,14 +2,16 @@ package org.infernus.idea.checkstyle.service.cmd;
 
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
+import org.infernus.idea.checkstyle.CheckstyleProjectService;
 import org.infernus.idea.checkstyle.checker.CheckStyleChecker;
+import org.infernus.idea.checkstyle.csapi.CheckstyleActions;
 import org.infernus.idea.checkstyle.csapi.TabWidthAndBaseDirProvider;
 import org.infernus.idea.checkstyle.exception.CheckStylePluginException;
-import org.infernus.idea.checkstyle.exception.CheckstyleServiceException;
 import org.infernus.idea.checkstyle.model.ConfigurationLocation;
 import org.infernus.idea.checkstyle.service.CheckstyleActionsImpl;
 import org.infernus.idea.checkstyle.service.FileUtil;
 import org.infernus.idea.checkstyle.service.StringConfigurationLocation;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,6 +45,15 @@ public class OpCreateCheckerTest
         Mockito.when(sConfigurationsMock.tabWidth()).thenReturn(2);
         Mockito.when(sConfigurationsMock.baseDir()).thenReturn(  //
                 Optional.of(new File(OpCreateCheckerTest.class.getResource(CONFIG_FILE).toURI()).getParent()));
+
+        CheckstyleProjectService csServiceMock = Mockito.mock(CheckstyleProjectService.class);
+        Mockito.when(csServiceMock.getCheckstyleInstance()).thenReturn(Mockito.mock(CheckstyleActions.class));
+        CheckstyleProjectService.activateMock4UnitTesting(csServiceMock);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        CheckstyleProjectService.activateMock4UnitTesting(null);
     }
 
 
@@ -76,7 +87,7 @@ public class OpCreateCheckerTest
 
         //noinspection ConstantConditions
         CheckStyleChecker checker = new CheckstyleActionsImpl(PROJECT).createChecker(null, configLoc, Collections
-                        .emptyMap(), sConfigurationsMock, getClass().getClassLoader());
+                .emptyMap(), sConfigurationsMock, getClass().getClassLoader());
         Assert.assertNotNull(checker);
     }
 }

--- a/src/main/java/org/infernus/idea/checkstyle/CheckStyleInspection.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckStyleInspection.java
@@ -87,7 +87,7 @@ public class CheckStyleInspection extends LocalInspectionTool {
 
             return checkerFactory(psiFile.getProject())
                     .checker(module, configurationLocation)
-                    .map(checker -> checker.scan(scannableFiles, plugin.getConfiguration()))
+                    .map(checker -> checker.scan(scannableFiles, plugin.getConfiguration().isSuppressingErrors()))
                     .map(results -> results.get(psiFile))
                     .orElseGet(() -> NO_PROBLEMS_FOUND);
 

--- a/src/main/java/org/infernus/idea/checkstyle/checker/CachedChecker.java
+++ b/src/main/java/org/infernus/idea/checkstyle/checker/CachedChecker.java
@@ -44,7 +44,7 @@ class CachedChecker {
         return (getTimeStamp() + CACHE_VALID_TIME) >= System.currentTimeMillis();
     }
 
-    public void destroy(@NotNull final Project pProject) {
-        checkStyleChecker.destroy(pProject);
+    public void destroy() {
+        checkStyleChecker.destroy();
     }
 }

--- a/src/main/java/org/infernus/idea/checkstyle/checker/CheckStyleChecker.java
+++ b/src/main/java/org/infernus/idea/checkstyle/checker/CheckStyleChecker.java
@@ -8,13 +8,18 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import org.infernus.idea.checkstyle.CheckStyleConfiguration;
 import org.infernus.idea.checkstyle.CheckstyleProjectService;
+import org.infernus.idea.checkstyle.csapi.CheckstyleActions;
 import org.infernus.idea.checkstyle.csapi.CheckstyleInternalObject;
 import org.jetbrains.annotations.NotNull;
+
 
 public class CheckStyleChecker
 {
     /** checker with config */
     private final CheckstyleInternalObject checkerWithConfig;
+
+    /** the service instance that was current when this object is created */
+    private final CheckstyleActions csServiceInstance;
 
     private final int tabWidth;
     private final Optional<String> baseDir;
@@ -22,8 +27,10 @@ public class CheckStyleChecker
     private final ClassLoader loaderOfCheckedCode;
 
 
-    public CheckStyleChecker(@NotNull final CheckstyleInternalObject pCheckerWithConfig, final int tabWidth, @NotNull
-    final Optional<String> baseDir, final ClassLoader pLoaderOfCheckedCode) {
+    public CheckStyleChecker(@NotNull final CheckstyleInternalObject pCheckerWithConfig, final int tabWidth,
+                             @NotNull final Optional<String> baseDir, final ClassLoader pLoaderOfCheckedCode,
+                             @NotNull final CheckstyleActions csServiceInstance) {
+        this.csServiceInstance = csServiceInstance;
         this.checkerWithConfig = pCheckerWithConfig;
         this.tabWidth = tabWidth;
         this.baseDir = baseDir;
@@ -31,18 +38,14 @@ public class CheckStyleChecker
     }
 
     @NotNull
-    public Map<PsiFile, List<Problem>> scan(@NotNull final List<ScannableFile> scannableFiles, @NotNull final
-    CheckStyleConfiguration pluginConfig) {
-
-        final CheckstyleProjectService csService = CheckstyleProjectService.getInstance(pluginConfig.getProject());
-        return csService.getCheckstyleInstance().scan(checkerWithConfig, scannableFiles, pluginConfig
-                .isSuppressingErrors(), tabWidth, baseDir);
+    public Map<PsiFile, List<Problem>> scan(@NotNull final List<ScannableFile> scannableFiles,
+                                            final boolean suppressErrors) {
+        return csServiceInstance.scan(checkerWithConfig, scannableFiles, suppressErrors, tabWidth, baseDir);
     }
 
 
-    public void destroy(@NotNull final Project pProject) {
-        final CheckstyleProjectService csService = CheckstyleProjectService.getInstance(pProject);
-        csService.getCheckstyleInstance().destroyChecker(checkerWithConfig);
+    public void destroy() {
+        csServiceInstance.destroyChecker(checkerWithConfig);
     }
 
 

--- a/src/main/java/org/infernus/idea/checkstyle/checker/ScanFiles.java
+++ b/src/main/java/org/infernus/idea/checkstyle/checker/ScanFiles.java
@@ -196,7 +196,7 @@ public class ScanFiles
             scannableFiles.addAll(ScannableFile.createAndValidate(filesToScan, plugin, module));
 
             return checkerFactory(module.getProject()).checker(module, configurationLocation).map(checker -> checker.scan
-                    (scannableFiles, plugin.getConfiguration())).orElseGet(Collections::emptyMap);
+                    (scannableFiles, plugin.getConfiguration().isSuppressingErrors())).orElseGet(Collections::emptyMap);
         } finally {
             scannableFiles.forEach(ScannableFile::deleteIfRequired);
         }


### PR DESCRIPTION
While we still don't know the exact cause of #291, I changed a few lines to help improve stability.
The cached checkers now retain an instance of the project service to which they are inextricably tied anyway. So calling *scan* or *destroy* on them could no longer throw a `CheckstyleVersionMixException`.
It would not, of course, relieve us from the responsibility to invalidate the cache properly, but it may help in some edge cases that we missed or in case of "unplanned race conditions" ...
Also added some try-finally blocks.