### PR TITLE
Verify test coverage for 'csaccess' source set during build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ matrix:
       jdk: oraclejdk8
     - os: osx
       osx_image: xcode8
+
+script:
+  - ./gradlew check jacocoCsaccessCoverageVerification

--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,9 @@ intellij {
     updateSinceUntilBuild = false
 }
 
-new CustomSourceSetCreator(project)
-        .establishCsAccessSourceSet()
-        .establishCsAccessTestSourceSet();
+final CustomSourceSetCreator customBuild = new CustomSourceSetCreator(project);
+customBuild.establishCsAccessSourceSet();
+customBuild.establishCsAccessTestSourceSet();
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8';
@@ -101,46 +101,20 @@ tasks.test.dependsOn rct;
 //   Cross-check 'csaccessTest' unit tests against the different Checkstyle runtimes
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-task xtest {
-    setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
-    setDescription('Runs the \'' + CustomSourceSetCreator.CSACCESSTEST_SOURCESET_NAME +
+Task xtestTask = tasks.create(CsaccessTestTask.XTEST_TASK_NAME);
+xtestTask.setGroup(CsaccessTestTask.XTEST_GROUP_NAME);
+xtestTask.setDescription('Runs the \'' + CustomSourceSetCreator.CSACCESSTEST_SOURCESET_NAME +
             '\' unit tests against all supported Checkstyle runtimes.');
-}
-tasks.check.dependsOn tasks.xtest;
+
+tasks.check.dependsOn xtestTask;
 supportedCsVersions.versions.each { final String csVersion ->
     if (supportedCsVersions.baseVersion != csVersion) {
         CsaccessTestTask xt = tasks.create(CsaccessTestTask.getTaskName(csVersion), CsaccessTestTask.class);
         xt.setCheckstyleVersion(csVersion, false);
-        tasks.xtest.dependsOn(xt);
+        xtestTask.dependsOn(xt);
     }
 }
-
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-//   Exclusive test coverage report for 'csaccess' classes
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-test.jacoco.enabled = false;
-task jacocoTestReport4csaccess(type: JacocoReport, dependsOn: tasks.withType(CsaccessTestTask)) {
-    description 'Generate exclusive JaCoCo test report on the \'' + CustomSourceSetCreator.CSACCESS_SOURCESET_NAME +
-            '\' classes';
-    reports {
-        xml.enabled = true;
-        csv.enabled = false;
-        html.enabled = true;
-    }
-    def SourceSet csaccessSourceSet = sourceSets.getByName(CustomSourceSetCreator.CSACCESS_SOURCESET_NAME);
-    classDirectories = files(csaccessSourceSet.output.classesDir);
-    sourceDirectories = csaccessSourceSet.java.sourceDirectories;
-    executionData = files(tasks.withType(CsaccessTestTask)*.name.collect {
-        new File("${buildDir}/jacoco", "${it}.exec")
-    });
-    // TODO We should fail the build if a certain coverage is not reached. This will be possible with Gradle 4.0 (see
-    // https://github.com/gradle/gradle/issues/824) or with a handcrafted workaround such as
-    // https://github.com/springfox/springfox/blob/fb780ee1f14627b239fba95730a69900b9b2313a/gradle/coverage.gradle
-}
-tasks.remove(tasks.jacocoTestReport);
-tasks.xtest.dependsOn tasks.jacocoTestReport4csaccess;
+customBuild.setupCoverageVerification();
 
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,3 +11,8 @@ dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8';
+    options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation';
+}

--- a/buildSrc/src/main/java/org/infernus/idea/checkstyle/build/CsaccessTestTask.java
+++ b/buildSrc/src/main/java/org/infernus/idea/checkstyle/build/CsaccessTestTask.java
@@ -22,6 +22,7 @@ public class CsaccessTestTask
         extends Test
 {
     public static final String XTEST_GROUP_NAME = "xtest";
+    public static final String XTEST_TASK_NAME = "xtest";
 
     public static final String NAME = "runCsaccessTests";
 
@@ -40,7 +41,7 @@ public class CsaccessTestTask
 
         dependsOn(project.getTasks().getByName(csaccessTestSourceSet.getClassesTaskName()));
 
-        configure((Closure) project.getProperties().get("testConfigClosure"));
+        configure((Closure<?>) project.getProperties().get("testConfigClosure"));
         setTestClassesDir(csaccessTestSourceSet.getOutput().getClassesDir());
     }
 

--- a/buildSrc/src/main/java/org/infernus/idea/checkstyle/build/CustomSourceSetCreator.java
+++ b/buildSrc/src/main/java/org/infernus/idea/checkstyle/build/CustomSourceSetCreator.java
@@ -31,7 +31,7 @@ public class CustomSourceSetCreator
     public static final String JACOCO_VERIFICATION_TASK_NAME =
             "jacoco" + capitalize(CSACCESS_SOURCESET_NAME) + "CoverageVerification";
 
-    private static final double MINIMUM_CSACCESS_COVERAGE = 0.89d;
+    private static final double MINIMUM_CSACCESS_COVERAGE = 0.88d;
 
     private final Project project;
 

--- a/buildSrc/src/main/java/org/infernus/idea/checkstyle/build/CustomSourceSetCreator.java
+++ b/buildSrc/src/main/java/org/infernus/idea/checkstyle/build/CustomSourceSetCreator.java
@@ -3,25 +3,60 @@ package org.infernus.idea.checkstyle.build;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
+import org.gradle.testing.jacoco.plugins.JacocoPluginExtension;
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension;
+import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification;
+import org.gradle.testing.jacoco.tasks.JacocoReport;
+import org.gradle.testing.jacoco.tasks.JacocoReportBase;
+import org.gradle.testing.jacoco.tasks.rules.JacocoLimit;
+import org.gradle.testing.jacoco.tasks.rules.JacocoViolationRule;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.util.stream.Collectors;
 
 
-public class CustomSourceSetCreator {
-
+public class CustomSourceSetCreator
+{
     public static final String CSACCESS_SOURCESET_NAME = "csaccess";
     public static final String CSACCESSTEST_SOURCESET_NAME = "csaccessTest";
+    public static final String JACOCO_REPORT_TASK_NAME =
+            "jacoco" + capitalize(CSACCESS_SOURCESET_NAME) + "Report";
+    public static final String JACOCO_VERIFICATION_TASK_NAME =
+            "jacoco" + capitalize(CSACCESS_SOURCESET_NAME) + "CoverageVerification";
+
+    private static final double MINIMUM_CSACCESS_COVERAGE = 0.89d;
 
     private final Project project;
 
-    public CustomSourceSetCreator(final Project pProject) {
+
+    public CustomSourceSetCreator(final Project pProject)
+    {
         project = pProject;
     }
 
 
-    public CustomSourceSetCreator establishCsAccessSourceSet() {
+    private static String capitalize(final String pString) {
+        String result = pString;
+        if (pString != null) {
+            final int strLen = pString.length();
+            if (strLen > 0) {
+                result = new StringBuilder(strLen + 1).append(Character.toTitleCase(pString.charAt(0)))
+                        .append(pString.substring(1)).toString();
+            }
+        }
+        return result;
+    }
+
+
+    public CustomSourceSetCreator establishCsAccessSourceSet()
+    {
 
         final SourceSetContainer sourceSets = (SourceSetContainer) project.getProperties().get("sourceSets");
         final SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
@@ -34,15 +69,16 @@ public class CustomSourceSetCreator {
 
         // Derive all its configurations from 'main', so 'csaccess' code can see 'main' code
         final ConfigurationContainer configurations = project.getConfigurations();
-        final Configuration compileConfig = configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME);
-        final Configuration compileOnlyConfig = configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME);
-        final Configuration compileClasspathConfig = configurations.getByName(JavaPlugin
-                .COMPILE_CLASSPATH_CONFIGURATION_NAME);
-        final Configuration runtimeConfig = configurations.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME);
+        final Configuration compileConfig = configurations.getByName(mainSourceSet.getCompileConfigurationName());
+        final Configuration compileOnlyConfig = configurations.getByName(mainSourceSet
+                .getCompileOnlyConfigurationName());
+        final Configuration compileClasspathConfig = configurations.getByName(mainSourceSet
+                .getCompileClasspathConfigurationName());
+        final Configuration runtimeConfig = configurations.getByName(mainSourceSet.getRuntimeConfigurationName());
         configurations.getByName(csaccessSourceSet.getCompileConfigurationName()).extendsFrom(compileConfig);
         configurations.getByName(csaccessSourceSet.getCompileOnlyConfigurationName()).extendsFrom(compileOnlyConfig);
-        configurations.getByName(csaccessSourceSet.getCompileClasspathConfigurationName())
-                .extendsFrom(compileClasspathConfig);
+        configurations.getByName(csaccessSourceSet.getCompileClasspathConfigurationName()).extendsFrom
+                (compileClasspathConfig);
         configurations.getByName(csaccessSourceSet.getRuntimeConfigurationName()).extendsFrom(runtimeConfig);
 
         // Wire task dependencies to match the classpath dependencies (arrow means "depends on"):
@@ -60,45 +96,45 @@ public class CustomSourceSetCreator {
     }
 
 
-    public CustomSourceSetCreator establishCsAccessTestSourceSet() {
+    public CustomSourceSetCreator establishCsAccessTestSourceSet()
+    {
 
         final SourceSetContainer sourceSets = (SourceSetContainer) project.getProperties().get("sourceSets");
         final SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
         final SourceSet csaccessSourceSet = sourceSets.getByName(CSACCESS_SOURCESET_NAME);
+        final SourceSet testSourceSet = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME);
 
         // Create the 'csaccess' source set
         final SourceSet csaccessTestSourceSet = sourceSets.create(CSACCESSTEST_SOURCESET_NAME);
-        csaccessTestSourceSet.setCompileClasspath(csaccessTestSourceSet.getCompileClasspath()
-                .plus(mainSourceSet.getOutput())
-                .plus(csaccessSourceSet.getOutput()));
-        csaccessTestSourceSet.setRuntimeClasspath(csaccessTestSourceSet.getRuntimeClasspath()
-                .plus(mainSourceSet.getOutput())
-                .plus(csaccessSourceSet.getOutput()));
+        csaccessTestSourceSet.setCompileClasspath(csaccessTestSourceSet.getCompileClasspath().  //
+                plus(mainSourceSet.getOutput()).plus(csaccessSourceSet.getOutput()));
+        csaccessTestSourceSet.setRuntimeClasspath(csaccessTestSourceSet.getRuntimeClasspath().  //
+                plus(mainSourceSet.getOutput()).plus(csaccessSourceSet.getOutput()));
         sourceSets.add(csaccessTestSourceSet);
 
         // Derive all its configurations from 'test' and 'csaccess'
         final ConfigurationContainer configurations = project.getConfigurations();
-        final Configuration csaccessCompileConfig = configurations
-                .getByName(csaccessSourceSet.getCompileConfigurationName());
-        final Configuration csaccessCompileOnlyConfig = configurations.getByName(
+        final Configuration csaccessCompileConfig = configurations.getByName(  //
+                csaccessSourceSet.getCompileConfigurationName());
+        final Configuration csaccessCompileOnlyConfig = configurations.getByName(  //
                 csaccessSourceSet.getCompileOnlyConfigurationName());
-        final Configuration csaccessCompileClasspathConfig = configurations.getByName(
+        final Configuration csaccessCompileClasspathConfig = configurations.getByName(  //
                 csaccessSourceSet.getCompileClasspathConfigurationName());
-        final Configuration csaccessRuntimeConfig = configurations.getByName(
+        final Configuration csaccessRuntimeConfig = configurations.getByName(  //
                 csaccessSourceSet.getRuntimeConfigurationName());
-        final Configuration testCompileConfig = configurations.getByName(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME);
-        final Configuration testCompileOnlyConfig = configurations.getByName(
-                JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME);
-        final Configuration testCompileClasspathConfig = configurations.getByName(
-                JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME);
-        final Configuration testRuntimeConfig = configurations.getByName(JavaPlugin.TEST_RUNTIME_CONFIGURATION_NAME);
-        configurations.getByName(csaccessTestSourceSet.getCompileConfigurationName()).
+        final Configuration testCompileConfig = configurations.getByName(testSourceSet.getCompileConfigurationName());
+        final Configuration testCompileOnlyConfig = configurations.getByName(  //
+                testSourceSet.getCompileOnlyConfigurationName());
+        final Configuration testCompileClasspathConfig = configurations.getByName(  //
+                testSourceSet.getCompileClasspathConfigurationName());
+        final Configuration testRuntimeConfig = configurations.getByName(testSourceSet.getRuntimeConfigurationName());
+        configurations.getByName(csaccessTestSourceSet.getCompileConfigurationName()).  //
                 extendsFrom(csaccessCompileConfig, testCompileConfig);
-        configurations.getByName(csaccessTestSourceSet.getCompileOnlyConfigurationName()).
+        configurations.getByName(csaccessTestSourceSet.getCompileOnlyConfigurationName()).  //
                 extendsFrom(csaccessCompileOnlyConfig, testCompileOnlyConfig);
-        configurations.getByName(csaccessTestSourceSet.getCompileClasspathConfigurationName()).
+        configurations.getByName(csaccessTestSourceSet.getCompileClasspathConfigurationName()).  //
                 extendsFrom(csaccessCompileClasspathConfig, testCompileClasspathConfig);
-        configurations.getByName(csaccessTestSourceSet.getRuntimeConfigurationName()).
+        configurations.getByName(csaccessTestSourceSet.getRuntimeConfigurationName()).  //
                 extendsFrom(csaccessRuntimeConfig, testRuntimeConfig);
 
         // Wire task dependencies to match the classpath dependencies (arrow means "depends on"):
@@ -111,5 +147,62 @@ public class CustomSourceSetCreator {
                 .getClassesTaskName()));
 
         return this;
+    }
+
+
+
+    public void setupCoverageVerification()
+    {
+        final TaskContainer tasks = project.getTasks();
+
+        // Disable JaCoCo for 'test' source set
+        final JacocoTaskExtension jacocoTestTaskExtension = (JacocoTaskExtension) tasks.getByName(
+                JavaPlugin.TEST_TASK_NAME).getExtensions().getByName(JacocoPluginExtension.TASK_EXTENSION_NAME);
+        jacocoTestTaskExtension.setEnabled(false);
+        tasks.remove(tasks.getByName("jacocoTestReport"));
+        tasks.remove(tasks.getByName("jacocoTestCoverageVerification"));
+
+        // Enable JaCoCo reporting for 'csaccess' source set
+        final JacocoReport jacocoReportTask = tasks.create(JACOCO_REPORT_TASK_NAME, JacocoReport.class);
+        jacocoReportTask.dependsOn(tasks.getByName(CsaccessTestTask.NAME),
+                tasks.getByName(CsaccessTestTask.XTEST_TASK_NAME));
+        jacocoReportTask.setDescription("Generate exclusive JaCoCo test report on the '"
+                + CSACCESS_SOURCESET_NAME + "' classes");
+        configureJacocoTask(jacocoReportTask);
+        jacocoReportTask.getReports().getXml().setEnabled(true);
+        jacocoReportTask.getReports().getCsv().setEnabled(false);
+        jacocoReportTask.getReports().getHtml().setEnabled(true);
+
+        // Verify minimum line coverage for 'csaccess' source set
+        final JacocoCoverageVerification jacocoVerificationTask = tasks.create(JACOCO_VERIFICATION_TASK_NAME,
+                JacocoCoverageVerification.class);
+        jacocoVerificationTask.dependsOn(jacocoReportTask);
+        jacocoVerificationTask.setDescription("Ensure that '" + CSACCESS_SOURCESET_NAME
+                + "' test coverage does not drop below a certain level");
+        configureJacocoTask(jacocoVerificationTask);
+        jacocoVerificationTask.getViolationRules().rule((final JacocoViolationRule rule) -> {
+            rule.limit((final JacocoLimit jacocoLimit) -> {
+                jacocoLimit.setMinimum(BigDecimal.valueOf(MINIMUM_CSACCESS_COVERAGE));
+            });
+        });
+
+        // Wire 'build' task so that it ensures coverage
+        tasks.getByName(LifecycleBasePlugin.BUILD_TASK_NAME).dependsOn(jacocoVerificationTask);
+    }
+
+
+    private void configureJacocoTask(final JacocoReportBase pJacocoTask)
+    {
+        pJacocoTask.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
+        final SourceSetContainer sourceSets = (SourceSetContainer) project.getProperties().get("sourceSets");
+        final SourceSet csaccessSourceSet = sourceSets.getByName(CSACCESS_SOURCESET_NAME);
+        pJacocoTask.setClassDirectories(project.files(csaccessSourceSet.getOutput().getClassesDir()));
+        pJacocoTask.setSourceDirectories(csaccessSourceSet.getJava().getSourceDirectories());
+
+        final FileCollection execFiles = project.files(project.getTasks().withType(CsaccessTestTask.class).stream()
+            .map((final CsaccessTestTask task) -> { //
+                return new File(project.getBuildDir() + "/jacoco", task.getName() + ".exec");
+            }).collect(Collectors.toList()));
+        pJacocoTask.setExecutionData(execFiles);
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip


### PR DESCRIPTION
Here's a little PR for one of the [To-Do comments in the build file](https://github.com/jshiell/checkstyle-idea/blob/5.3.0/build.gradle#L138-L140), which was that we should verify test coverage for source files in the 'csaccess' source set during build. The rationale being that if only one call to the Checkstyle API remains uncovered, it may break the plugin with the next Checkstyle version.

I set the initial required coverage to our current coverage (which seems fine). It can be changed by modifying the [MINIMUM_CSACCESS_COVERAGE](https://github.com/tsjensen/checkstyle-idea/blob/cov-check/buildSrc/src/main/java/org/infernus/idea/checkstyle/build/CustomSourceSetCreator.java#L34) constant.

This feature is made possible by the fact that Gradle decided to bring forward the [feature](https://github.com/gradle/gradle/issues/824) originally planned for Gradle 4.0. Coverage verification is now possible starting with Gradle 3.4. I still had to upgrade from Gradle 3.2.1 which we were using.

Hope this helps!