### PR TITLE
Add ImportOrderImporter (#314)

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/importer/modules/ImportOrderImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/modules/ImportOrderImporter.java
@@ -1,0 +1,206 @@
+package org.infernus.idea.checkstyle.importer.modules;
+
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.PackageEntry;
+import com.intellij.psi.codeStyle.PackageEntryTable;
+import java.util.HashSet;
+import org.infernus.idea.checkstyle.importer.ModuleImporter;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public class ImportOrderImporter extends ModuleImporter {
+
+    private static final String GROUPS = "groups";
+    private static final String SEPARATED = "separated";
+    private static final String OPTION = "option";
+
+    private String[] groups;
+    private boolean separated = false;
+    private StaticImportPosition staticPosition;
+
+    @Override
+    protected void handleAttribute(@NotNull String attrName, @NotNull String attrValue) {
+        switch (attrName) {
+            case GROUPS:
+                groups = attrValue.split(",");
+                break;
+            case SEPARATED:
+                separated = Boolean.parseBoolean(attrValue);
+                break;
+            case OPTION:
+                staticPosition = StaticImportPosition.valueOf(attrValue.toUpperCase());
+                break;
+        }
+    }
+
+    @Override
+    public void importTo(@NotNull CodeStyleSettings settings) {
+        if (groups != null) {
+            processGroupsAttribute(groups, settings);
+        }
+
+        if (staticPosition == null) {
+            processSeparatedAttribute(separated, settings);
+        } else {
+            if (staticPosition == StaticImportPosition.ABOVE || staticPosition == StaticImportPosition.UNDER) {
+                // we are applying the attributes in reverse so that we do not separate blocks containing static and
+                // non-static imports for the same package
+                processSeparatedAttribute(separated, settings);
+                processOptionAttribute(staticPosition, settings);
+            } else {
+                processOptionAttribute(staticPosition, settings);
+                processSeparatedAttribute(separated, settings);
+            }
+        }
+    }
+
+    private static void processGroupsAttribute(@NotNull String[] groups, @NotNull CodeStyleSettings settings) {
+        PackageEntryTable importTable = new PackageEntryTable();
+
+        for (String group : groups) {
+            if (group.equals("*")) {
+                importTable.addEntry(PackageEntry.ALL_OTHER_IMPORTS_ENTRY);
+            } else {
+                importTable.addEntry(new PackageEntry(false, group, true));
+            }
+        }
+        settings.IMPORT_LAYOUT_TABLE.copyFrom(importTable);
+    }
+
+    private static void processSeparatedAttribute(boolean separated, @NotNull CodeStyleSettings settings) {
+        PackageEntryTable importTable = new PackageEntryTable();
+
+        if (settings.IMPORT_LAYOUT_TABLE.getEntryCount() < 1) {
+            // nothing to separate
+            return;
+        }
+
+        for (PackageEntry entry : settings.IMPORT_LAYOUT_TABLE.getEntries()) {
+            if (entry != PackageEntry.BLANK_LINE_ENTRY) {
+                importTable.addEntry(entry);
+                if (separated) {
+                    importTable.addEntry(PackageEntry.BLANK_LINE_ENTRY);
+                }
+            }
+        }
+
+        // remove blank line at the very end if present
+        if (importTable.getEntryAt(importTable.getEntryCount() - 1) == PackageEntry.BLANK_LINE_ENTRY) {
+            importTable.removeEntryAt(importTable.getEntryCount() - 1);
+        }
+
+        settings.IMPORT_LAYOUT_TABLE.copyFrom(importTable);
+    }
+
+    private static void processOptionAttribute(@NotNull StaticImportPosition staticImportPosition, @NotNull CodeStyleSettings settings) {
+        switch (staticImportPosition) {
+            case TOP:
+                // remove other instances of PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY from the table
+                // iterate from the end so we can remove elements without having to modify the index afterwards
+                for (int x = settings.IMPORT_LAYOUT_TABLE.getEntryCount() - 1; x >= 0; x--) {
+                    if (settings.IMPORT_LAYOUT_TABLE.getEntryAt(x) == PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY) {
+                        settings.IMPORT_LAYOUT_TABLE.removeEntryAt(x);
+                    }
+                }
+                settings.IMPORT_LAYOUT_TABLE.insertEntryAt(PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY, 0);
+                break;
+            case BOTTOM:
+                // remove other instances of PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY from the table
+                // iterate from the end so we can remove elements without having to modify the index afterwards
+                for (int x = settings.IMPORT_LAYOUT_TABLE.getEntryCount() - 1; x >= 0; x--) {
+                    if (settings.IMPORT_LAYOUT_TABLE.getEntryAt(x) == PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY) {
+                        settings.IMPORT_LAYOUT_TABLE.removeEntryAt(x);
+                    }
+                }
+                settings.IMPORT_LAYOUT_TABLE.addEntry(PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY);
+                break;
+            case INFLOW:
+                settings.LAYOUT_STATIC_IMPORTS_SEPARATELY = false;
+                // remove all static imports, in-line with IntelliJ's behavior
+                // iterate from the end so we can remove elements without having to modify the index afterwards
+                for (int x = settings.IMPORT_LAYOUT_TABLE.getEntryCount() - 1; x >= 0; x--) {
+                    if (settings.IMPORT_LAYOUT_TABLE.getEntryAt(x).isStatic()) {
+                        settings.IMPORT_LAYOUT_TABLE.removeEntryAt(x);
+                    }
+                }
+                break;
+            case ABOVE:
+            case UNDER:
+                // If the table contains both a static and non-static entry for a given package the position of the
+                // non-static import will be used for the import group.
+                // To be able to decide whether we have to insert a non-static import when encountering a static import
+                // we build an index here for all non-static imports.
+                HashSet<String> nonStaticImports = new HashSet<>();
+                for (PackageEntry entry : settings.IMPORT_LAYOUT_TABLE.getEntries()) {
+                    if (!entry.isStatic()) {
+                        nonStaticImports.add(entry.getPackageName());
+                    }
+                }
+
+                PackageEntryTable importTable = new PackageEntryTable();
+
+                for (PackageEntry entry : settings.IMPORT_LAYOUT_TABLE.getEntries()) {
+
+                    if (entry == PackageEntry.BLANK_LINE_ENTRY) {
+                        importTable.addEntry(entry);
+                        continue;
+                    }
+
+                    // The following blocks basically all work the same way:
+                    //
+                    // If we encounter a non-static import we add it to the table along with a static import
+                    // above or under it.
+                    //
+                    // If we encounter a static import we check whether a non-static import for the same package exists
+                    // using the index we built earlier.
+                    // If a non-static import exists we skip the current static import. It will be added later when we
+                    // arrive at the non-static import.
+                    // If no non-static import exists we add the current static import to the table along with a
+                    // non-static import above or under it.
+                    if (entry == PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY && !nonStaticImports.contains(PackageEntry.ALL_OTHER_IMPORTS_ENTRY.getPackageName())) {
+                        if (staticImportPosition == StaticImportPosition.ABOVE) {
+                            importTable.addEntry(PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY);
+                            importTable.addEntry(PackageEntry.ALL_OTHER_IMPORTS_ENTRY);
+                        } else {
+                            importTable.addEntry(PackageEntry.ALL_OTHER_IMPORTS_ENTRY);
+                            importTable.addEntry(PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY);
+                        }
+                    } else if (entry == PackageEntry.ALL_OTHER_IMPORTS_ENTRY) {
+                        if (staticImportPosition == StaticImportPosition.ABOVE) {
+                            importTable.addEntry(PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY);
+                            importTable.addEntry(PackageEntry.ALL_OTHER_IMPORTS_ENTRY);
+                        } else {
+                            importTable.addEntry(PackageEntry.ALL_OTHER_IMPORTS_ENTRY);
+                            importTable.addEntry(PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY);
+                        }
+                    } else if (entry.isStatic() && !nonStaticImports.contains(entry.getPackageName())) {
+                        if (staticImportPosition == StaticImportPosition.ABOVE) {
+                            importTable.addEntry(entry);
+                            importTable.addEntry(new PackageEntry(false, entry.getPackageName(), true));
+                        } else {
+                            importTable.addEntry(new PackageEntry(false, entry.getPackageName(), true));
+                            importTable.addEntry(entry);
+                        }
+                    } else { // non-static import
+                        if (staticImportPosition == StaticImportPosition.ABOVE) {
+                            importTable.addEntry(new PackageEntry(true, entry.getPackageName(), true));
+                            importTable.addEntry(entry);
+                        } else {
+                            importTable.addEntry(entry);
+                            importTable.addEntry(new PackageEntry(true, entry.getPackageName(), true));
+                        }
+                    }
+                }
+                settings.IMPORT_LAYOUT_TABLE.copyFrom(importTable);
+                break;
+        }
+    }
+
+    private enum StaticImportPosition {
+        TOP,
+        ABOVE,
+        UNDER,
+        INFLOW,
+        BOTTOM
+    }
+}

--- a/src/test/java/org/infernus/idea/checkstyle/importer/CodeStyleImporterTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/importer/CodeStyleImporterTest.java
@@ -5,6 +5,8 @@ import com.intellij.lang.xml.XMLLanguage;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.intellij.psi.codeStyle.PackageEntry;
+import com.intellij.psi.codeStyle.PackageEntryTable;
 import com.intellij.testFramework.LightPlatformTestCase;
 import org.infernus.idea.checkstyle.CheckStyleConfiguration;
 import org.infernus.idea.checkstyle.CheckstyleProjectService;
@@ -238,5 +240,239 @@ public class CodeStyleImporterTest
         indentOptions.CONTINUATION_INDENT_SIZE = 4;
     }
 
+    public void testImportOrderImporter() throws Exception {
+        // group attribute
+        {
+            importConfiguration(
+                    inTreeWalker(
+                            " <module name=\"ImportOrder\">\n" +
+                            "            <property name=\"groups\" value=\"my.custom.package,java,*\"/>\n" +
+                            "</module>"
+                    )
+            );
+            PackageEntry[] expected = new PackageEntry[]{
+                    new PackageEntry(false, "my.custom.package", true),
+                    new PackageEntry(false, "java", true),
+                    PackageEntry.ALL_OTHER_IMPORTS_ENTRY
+            };
+
+            comparePackageEntries(expected, codeStyleSettings.IMPORT_LAYOUT_TABLE);
+        }
+
+        // staticPosition attribute - top
+        {
+            importConfiguration(
+                    inTreeWalker(
+                            " <module name=\"ImportOrder\">\n" +
+                            "            <property name=\"groups\" value=\"my.custom.package,*\"/>\n" +
+                            "            <property name=\"option\" value=\"top\"/>\n" +
+                            "</module>"
+                    )
+            );
+            PackageEntry[] expected = new PackageEntry[]{
+                    PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY,
+                    new PackageEntry(false, "my.custom.package", true),
+                    PackageEntry.ALL_OTHER_IMPORTS_ENTRY,
+                    };
+
+            comparePackageEntries(expected, codeStyleSettings.IMPORT_LAYOUT_TABLE);
+        }
+
+        // staticPosition attribute - bottom
+        {
+            importConfiguration(
+                    inTreeWalker(
+                            " <module name=\"ImportOrder\">\n" +
+                            "            <property name=\"groups\" value=\"my.custom.package,*\"/>\n" +
+                            "            <property name=\"option\" value=\"bottom\"/>\n" +
+                            "</module>"
+                    )
+            );
+            PackageEntry[] expected = new PackageEntry[]{
+                    new PackageEntry(false, "my.custom.package", true),
+                    PackageEntry.ALL_OTHER_IMPORTS_ENTRY,
+                    PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY,
+                    };
+
+            comparePackageEntries(expected, codeStyleSettings.IMPORT_LAYOUT_TABLE);
+        }
+
+        // staticPosition attribute - above
+        {
+            importConfiguration(
+                    inTreeWalker(
+                            " <module name=\"ImportOrder\">\n" +
+                            "            <property name=\"groups\" value=\"my.custom.package,*\"/>\n" +
+                            "            <property name=\"option\" value=\"above\"/>\n" +
+                            "</module>"
+                    )
+            );
+            PackageEntry[] expected = new PackageEntry[]{
+                    new PackageEntry(true, "my.custom.package", true),
+                    new PackageEntry(false, "my.custom.package", true),
+                    PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY,
+                    PackageEntry.ALL_OTHER_IMPORTS_ENTRY,
+                    };
+
+            comparePackageEntries(expected, codeStyleSettings.IMPORT_LAYOUT_TABLE);
+        }
+
+        // staticPosition attribute - under
+        {
+            importConfiguration(
+                    inTreeWalker(
+                            " <module name=\"ImportOrder\">\n" +
+                            "            <property name=\"groups\" value=\"my.custom.package,*\"/>\n" +
+                            "            <property name=\"option\" value=\"under\"/>\n" +
+                            "</module>"
+                    )
+            );
+            PackageEntry[] expected = new PackageEntry[]{
+                    new PackageEntry(false, "my.custom.package", true),
+                    new PackageEntry(true, "my.custom.package", true),
+                    PackageEntry.ALL_OTHER_IMPORTS_ENTRY,
+                    PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY,
+                    };
+
+            comparePackageEntries(expected, codeStyleSettings.IMPORT_LAYOUT_TABLE);
+        }
+
+        // staticPosition attribute - inflow
+        {
+            importConfiguration(
+                    inTreeWalker(
+                            " <module name=\"ImportOrder\">\n" +
+                            "            <property name=\"groups\" value=\"my.custom.package,*\"/>\n" +
+                            "            <property name=\"option\" value=\"inflow\"/>\n" +
+                            "</module>"
+                    )
+            );
+            PackageEntry[] expected = new PackageEntry[]{
+                    new PackageEntry(false, "my.custom.package", true),
+                    PackageEntry.ALL_OTHER_IMPORTS_ENTRY,
+                    };
+
+            assertEquals(false, codeStyleSettings.LAYOUT_STATIC_IMPORTS_SEPARATELY);
+            comparePackageEntries(expected, codeStyleSettings.IMPORT_LAYOUT_TABLE);
+        }
+
+        // separated attribute - top
+        {
+            importConfiguration(
+                    inTreeWalker(
+                            " <module name=\"ImportOrder\">\n" +
+                            "            <property name=\"groups\" value=\"my.custom.package,*\"/>\n" +
+                            "            <property name=\"option\" value=\"top\"/>\n" +
+                            "            <property name=\"separated\" value=\"true\"/>\n" +
+                            "</module>"
+                    )
+            );
+            PackageEntry[] expected = new PackageEntry[]{
+                    PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY,
+                    PackageEntry.BLANK_LINE_ENTRY,
+                    new PackageEntry(false, "my.custom.package", true),
+                    PackageEntry.BLANK_LINE_ENTRY,
+                    PackageEntry.ALL_OTHER_IMPORTS_ENTRY,
+                    };
+
+            assertEquals(false, codeStyleSettings.LAYOUT_STATIC_IMPORTS_SEPARATELY);
+            comparePackageEntries(expected, codeStyleSettings.IMPORT_LAYOUT_TABLE);
+        }
+
+        // separate attribute - bottom
+        {
+            importConfiguration(
+                    inTreeWalker(
+                            " <module name=\"ImportOrder\">\n" +
+                            "            <property name=\"groups\" value=\"my.custom.package,*\"/>\n" +
+                            "            <property name=\"option\" value=\"bottom\"/>\n" +
+                            "            <property name=\"separated\" value=\"true\"/>\n" +
+                            "</module>"
+                    )
+            );
+            PackageEntry[] expected = new PackageEntry[]{
+                    new PackageEntry(false, "my.custom.package", true),
+                    PackageEntry.BLANK_LINE_ENTRY,
+                    PackageEntry.ALL_OTHER_IMPORTS_ENTRY,
+                    PackageEntry.BLANK_LINE_ENTRY,
+                    PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY,
+                    };
+
+            assertEquals(false, codeStyleSettings.LAYOUT_STATIC_IMPORTS_SEPARATELY);
+            comparePackageEntries(expected, codeStyleSettings.IMPORT_LAYOUT_TABLE);
+        }
+
+        // separate attribute - above
+        {
+            importConfiguration(
+                    inTreeWalker(
+                            " <module name=\"ImportOrder\">\n" +
+                            "            <property name=\"groups\" value=\"my.custom.package,*\"/>\n" +
+                            "            <property name=\"option\" value=\"above\"/>\n" +
+                            "            <property name=\"separated\" value=\"true\"/>\n" +
+                            "</module>"
+                    )
+            );
+            PackageEntry[] expected = new PackageEntry[]{
+                    new PackageEntry(true, "my.custom.package", true),
+                    new PackageEntry(false, "my.custom.package", true),
+                    PackageEntry.BLANK_LINE_ENTRY,
+                    PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY,
+                    PackageEntry.ALL_OTHER_IMPORTS_ENTRY,
+                    };
+
+            comparePackageEntries(expected, codeStyleSettings.IMPORT_LAYOUT_TABLE);
+        }
+
+        // separate attribute - under
+        {
+            importConfiguration(
+                    inTreeWalker(
+                            " <module name=\"ImportOrder\">\n" +
+                            "            <property name=\"groups\" value=\"my.custom.package,*\"/>\n" +
+                            "            <property name=\"option\" value=\"under\"/>\n" +
+                            "            <property name=\"separated\" value=\"true\"/>\n" +
+                            "</module>"
+                    )
+            );
+            PackageEntry[] expected = new PackageEntry[]{
+                    new PackageEntry(false, "my.custom.package", true),
+                    new PackageEntry(true, "my.custom.package", true),
+                    PackageEntry.BLANK_LINE_ENTRY,
+                    PackageEntry.ALL_OTHER_IMPORTS_ENTRY,
+                    PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY,
+                    };
+
+            comparePackageEntries(expected, codeStyleSettings.IMPORT_LAYOUT_TABLE);
+        }
+
+        // separate attribute - inflow
+        {
+            importConfiguration(
+                    inTreeWalker(
+                            " <module name=\"ImportOrder\">\n" +
+                            "            <property name=\"groups\" value=\"my.custom.package,*\"/>\n" +
+                            "            <property name=\"option\" value=\"inflow\"/>\n" +
+                            "            <property name=\"separated\" value=\"true\"/>\n" +
+                            "</module>"
+                    )
+            );
+            PackageEntry[] expected = new PackageEntry[]{
+                    new PackageEntry(false, "my.custom.package", true),
+                    PackageEntry.BLANK_LINE_ENTRY,
+                    PackageEntry.ALL_OTHER_IMPORTS_ENTRY,
+                    };
+
+            assertEquals(false, codeStyleSettings.LAYOUT_STATIC_IMPORTS_SEPARATELY);
+            comparePackageEntries(expected, codeStyleSettings.IMPORT_LAYOUT_TABLE);
+        }
+    }
+
+    private static void comparePackageEntries(PackageEntry[] expected, PackageEntryTable actual) {
+        assertEquals(expected.length, actual.getEntryCount());
+        for (int x = 0; x < expected.length; x++) {
+            assertEquals(expected[x], actual.getEntries()[x]);
+        }
+    }
 
 }


### PR DESCRIPTION
This PR adds an Importer for the `ImportOrder` module. The supported attributes include `groups`, `separated` and `option`.

The attributes are applied separately; but the order in which `separated` and `groups` are applied varies a bit depending on the configuration as documented in `ImportOrderImporter#importTo`.

The `groups` attribute implementation is straight-forward; it builds a new `PackageEntryTable` containing the configured packaged and overwrites the existing table.

The `separated` attribute implementation again rebuilds a `PackageEntryTable` by inserting all entries from the existing one, while filtering existing blank lines, and inserting new blank lines if necessary.

The `option` attribute implementation is by far the trickiest one, specifically the `above`/`under` options. 
One problem was that given this layout
```
static my.package.com.*;
java.util.*;
my.package.com.*;
```
it is not well-defined what the position of the `my.package.com.*` group should be, as both
```
java.util.*;
static my.package.com.*;
my.package.com.*;
```
and
```
static my.package.com.*;
my.package.com.*;
java.util.*;
```
would be valid. I opted for honoring the location of the non-static import (the first layout).
The second problem was that when encountering a static import one would now have to know whether a non-static import for the same package exists somewhere else. If so we have to move the static one, if not we have to add a new non-static import.

For this purpose I'm first building an index of all non-static imports as a `HashSet`, and query it for every static import encountered. If there is a non-static import we actually just skip the static one, and by default add a static import whenever we encounter a non-static one.

There is one flaw that I'm not sure how to deal with: When `option` is not configured you can end up with an import layout that doesn't include static imports at all, since the `groups` attribute only defines non-static imports. One could use the default value for `option` (under) to work-around this, but IMO it is a somewhat odd default that may do more harm than good.