### PR TITLE
Add AvoidStartImportImporter (#318)

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/importer/modules/AvoidStarImportImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/modules/AvoidStarImportImporter.java
@@ -1,0 +1,54 @@
+package org.infernus.idea.checkstyle.importer.modules;
+
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.PackageEntry;
+import com.intellij.psi.codeStyle.PackageEntryTable;
+import org.infernus.idea.checkstyle.importer.ModuleImporter;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public class AvoidStarImportImporter extends ModuleImporter {
+
+    private static final String EXCLUDES = "excludes";
+    private static final String ALLOW_CLASS_STAR_IMPORT = "allowClassImports";
+    private static final String ALLOW_STATIC_STAR_IMPORT = "allowStaticMemberImports";
+
+    private boolean allowClassStarImports;
+    private boolean allowStaticStarImports;
+    private String[] excludes;
+
+    @Override
+    protected void handleAttribute(@NotNull String attrName, @NotNull String attrValue) {
+        switch (attrName) {
+            case EXCLUDES:
+                excludes = attrValue.split(",");
+                break;
+            case ALLOW_CLASS_STAR_IMPORT:
+                allowClassStarImports = Boolean.parseBoolean(attrValue);
+                break;
+            case ALLOW_STATIC_STAR_IMPORT:
+                allowStaticStarImports = Boolean.parseBoolean(attrValue);
+                break;
+        }
+
+    }
+
+    @Override
+    public void importTo(@NotNull CodeStyleSettings settings) {
+        if (!allowClassStarImports) {
+            settings.CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND = 999;
+        }
+
+        if (!allowStaticStarImports) {
+            settings.NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND = 999;
+        }
+
+        PackageEntryTable excludeTable = new PackageEntryTable();
+        if (excludes != null) {
+            for (String exclude : excludes) {
+                excludeTable.addEntry(new PackageEntry(false, exclude, false));
+            }
+        }
+        settings.PACKAGES_TO_USE_IMPORT_ON_DEMAND.copyFrom(excludeTable);
+    }
+}

--- a/src/test/java/org/infernus/idea/checkstyle/importer/CodeStyleImporterTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/importer/CodeStyleImporterTest.java
@@ -475,4 +475,82 @@ public class CodeStyleImporterTest
         }
     }
 
+    public void testAvoidStartImportImporter() throws Exception {
+        resetAvoidStarImportSettings(codeStyleSettings);
+        importConfiguration(
+                inTreeWalker(
+                        " <module name=\"AvoidStarImport\">\n" +
+                        "</module>"
+                )
+        );
+
+        assertEquals(999, codeStyleSettings.CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND);
+        assertEquals(999, codeStyleSettings.NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND);
+        assertEquals(0, codeStyleSettings.PACKAGES_TO_USE_IMPORT_ON_DEMAND.getEntryCount());
+
+        resetAvoidStarImportSettings(codeStyleSettings);
+        importConfiguration(
+                inTreeWalker(
+                        " <module name=\"AvoidStarImport\">\n" +
+                        "            <property name=\"allowClassImports\" value=\"true\"/>\n" +
+                        "            <property name=\"allowStaticMemberImports\" value=\"true\"/>\n" +
+                        "</module>"
+                )
+        );
+
+        assertEquals(1, codeStyleSettings.NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND);
+        assertEquals(1, codeStyleSettings.CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND);
+        assertEquals(0, codeStyleSettings.PACKAGES_TO_USE_IMPORT_ON_DEMAND.getEntryCount());
+
+        resetAvoidStarImportSettings(codeStyleSettings);
+        importConfiguration(
+                inTreeWalker(
+                        " <module name=\"AvoidStarImport\">\n" +
+                        "            <property name=\"allowStaticMemberImports\" value=\"true\"/>\n" +
+                        "</module>"
+                )
+        );
+
+        assertEquals(999, codeStyleSettings.CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND);
+        assertEquals(1, codeStyleSettings.NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND);
+        assertEquals(0, codeStyleSettings.PACKAGES_TO_USE_IMPORT_ON_DEMAND.getEntryCount());
+
+        codeStyleSettings.CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND = 1;
+
+        resetAvoidStarImportSettings(codeStyleSettings);
+        importConfiguration(
+                inTreeWalker(
+                        " <module name=\"AvoidStarImport\">\n" +
+                        "            <property name=\"allowClassImports\" value=\"true\"/>\n" +
+                        "</module>"
+                )
+        );
+
+        assertEquals(1, codeStyleSettings.CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND);
+        assertEquals(999, codeStyleSettings.NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND);
+        assertEquals(0, codeStyleSettings.PACKAGES_TO_USE_IMPORT_ON_DEMAND.getEntryCount());
+
+        resetAvoidStarImportSettings(codeStyleSettings);
+        importConfiguration(
+                inTreeWalker(
+                        " <module name=\"AvoidStarImport\">\n" +
+                        "            <property name=\"excludes\" value=\"a.b.c,d.e.f\"/>\n" +
+                        "</module>"
+                )
+        );
+
+        PackageEntry[] expected = new PackageEntry[]{
+                new PackageEntry(false, "a.b.c", false),
+                new PackageEntry(false, "d.e.f", false),
+                };
+
+        comparePackageEntries(expected, codeStyleSettings.PACKAGES_TO_USE_IMPORT_ON_DEMAND);
+    }
+
+    private static void resetAvoidStarImportSettings(CodeStyleSettings settings) {
+        settings.NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND = 1;
+        settings.CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND = 1;
+        settings.PACKAGES_TO_USE_IMPORT_ON_DEMAND.copyFrom(new PackageEntryTable());
+    }
+
 }


### PR DESCRIPTION
This PR adds an Importer for the `AvoidStartImport` module. The supported attributes include `excludes`, `allowClassImports` and `allowStaticMemberImports`.

Star imports are disabled by setting the class/import count threshold to 999. As far as I'm aware this is the common way of doing it.

If `allowClassImports` or `allowStaticMemberImports` are set to `true` the corresponding setting is not modified, whatever it may be, as it isn't strictly necessary.