### PR TITLE
Add ability to replace configured Checkstyle versions with compatible ones

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/CheckStyleConfiguration.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckStyleConfiguration.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -153,7 +154,7 @@ public class CheckStyleConfiguration
         List<ConfigurationLocation> result = pLoadedMap.entrySet().stream()
                 .filter(this::propertyIsALocation)
                 .map(e -> deserialiseLocation(pLoadedMap, e.getKey()))
-                .filter(cl -> cl != null)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
         ensureBundledConfigs(result);  // useful for migration, or when config file edited manually
         return result;
@@ -365,10 +366,14 @@ public class CheckStyleConfiguration
         return null;
     }
 
+    @NotNull
     private String readCheckstyleVersion(@NotNull final Map<String, String> pLoadedMap) {
+        final VersionListReader vlr = new VersionListReader();
         String result = pLoadedMap.get(CHECKSTYLE_VERSION_SETTING);
         if (result == null) {
-            result = new VersionListReader().getDefaultVersion();
+            result = vlr.getDefaultVersion();
+        } else {
+            result = vlr.getReplacementMap().getOrDefault(result, result);
         }
         return result;
     }

--- a/src/main/java/org/infernus/idea/checkstyle/VersionListReader.java
+++ b/src/main/java/org/infernus/idea/checkstyle/VersionListReader.java
@@ -1,14 +1,21 @@
 package org.infernus.idea.checkstyle;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import com.intellij.openapi.util.Pair;
 import org.apache.commons.io.IOUtils;
 import org.infernus.idea.checkstyle.exception.CheckStylePluginException;
 import org.infernus.idea.checkstyle.util.Strings;
 import org.jetbrains.annotations.NotNull;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.*;
-import java.util.function.Function;
 
 
 /**
@@ -21,8 +28,10 @@ class VersionListReader
 
     private static final String PROP_NAME_JAVA7 = "checkstyle.versions.java7";
     private static final String PROP_NAME_JAVA8 = "checkstyle.versions.java8";
+    private static final String PROP_VERSION_MAP = "checkstyle.versions.map";
 
     private final SortedSet<String> supportedVersions;
+    private final SortedMap<String, String> replacementMap;
 
 
     VersionListReader() {
@@ -30,27 +39,9 @@ class VersionListReader
     }
 
     VersionListReader(@NotNull final String pPropertyFile) {
-        supportedVersions = readSupportedVersions(pPropertyFile);
-    }
-
-
-    /**
-     * Read the supported Checkstyle versions from the config properties file.
-     *
-     * @param pPropertyFile file name of the property file to be passed to {@link ClassLoader#getResourceAsStream}
-     * @return the supported versions which match the Java level of the current JVM
-     */
-    @NotNull
-    private SortedSet<String> readSupportedVersions(@NotNull final String pPropertyFile) {
         final Properties props = readProperties(pPropertyFile);
-        final String javaVersion = Runtime.class.getPackage().getSpecificationVersion();
-
-        final SortedSet<String> theVersions = new TreeSet<>(new VersionComparator());
-        theVersions.addAll(readVersions(pPropertyFile, props, PROP_NAME_JAVA7));
-        if (!javaVersion.startsWith("1.7")) {
-            theVersions.addAll(readVersions(pPropertyFile, props, PROP_NAME_JAVA8));
-        }
-        return Collections.unmodifiableSortedSet(theVersions);
+        supportedVersions = readSupportedVersions(pPropertyFile, props);
+        replacementMap = readVersionMap(pPropertyFile, props, supportedVersions);
     }
 
 
@@ -81,6 +72,27 @@ class VersionListReader
     }
 
 
+    /**
+     * Read the supported Checkstyle versions from the config properties file.
+     *
+     * @param pPropertyFile file name of the property file to be passed to {@link ClassLoader#getResourceAsStream}
+     * @param props the properties read from the property file
+     * @return the supported versions which match the Java level of the current JVM
+     */
+    @NotNull
+    private SortedSet<String> readSupportedVersions(@NotNull final String pPropertyFile,
+                                                    @NotNull final Properties props) {
+        final String javaVersion = Runtime.class.getPackage().getSpecificationVersion();
+
+        final SortedSet<String> theVersions = new TreeSet<>(new VersionComparator());
+        theVersions.addAll(readVersions(pPropertyFile, props, PROP_NAME_JAVA7));
+        if (!javaVersion.startsWith("1.7")) {
+            theVersions.addAll(readVersions(pPropertyFile, props, PROP_NAME_JAVA8));
+        }
+        return Collections.unmodifiableSortedSet(theVersions);
+    }
+
+
     @NotNull
     private Set<String> readVersions(@NotNull final String pPropertyFile, @NotNull final Properties props,
                                      @NotNull final String propertyName) {
@@ -107,6 +119,63 @@ class VersionListReader
 
 
     @NotNull
+    private SortedMap<String, String> readVersionMap(@NotNull final String pPropertyFile,
+                                                     @NotNull final Properties props,
+                                                     @NotNull final SortedSet<String> pSupportedVersions) {
+        final String propertyValue = props.getProperty(PROP_VERSION_MAP);
+        if (Strings.isBlank(propertyValue)) {
+            throw new CheckStylePluginException("Internal error: Property '" + PROP_VERSION_MAP + "' missing from "
+                    + "configuration file '" + pPropertyFile + "'");
+        }
+
+        final String[] mappings = propertyValue.trim().split("\\s*,\\s*");
+        final SortedMap<String, String> result = new TreeMap<>(new VersionComparator());
+        for (final String mapping : mappings) {
+            if (!mapping.isEmpty()) {
+                final Pair<String, String> validMapping = readValidMapping(pPropertyFile, mapping, pSupportedVersions);
+                if (result.containsKey(validMapping.getFirst())) {
+                    throw new CheckStylePluginException("Internal error: Property '" + PROP_VERSION_MAP + "' "
+                            + "contains duplicate mapping \"" + mapping + "\" in configuration file '" + pPropertyFile
+                            + "'");
+                }
+                result.put(validMapping.getFirst(), validMapping.getSecond());
+            }
+        }
+        return Collections.unmodifiableSortedMap(result);
+    }
+
+
+    private Pair<String, String> readValidMapping(@NotNull final String pPropertyFile, @NotNull final String
+            pMapping, @NotNull final SortedSet<String> pSupportedVersions) {
+
+        final String[] kv = pMapping.split("\\s*->\\s*");
+        if (kv.length != 2) {
+            throw new CheckStylePluginException("Internal error: Property '" + PROP_VERSION_MAP + "' contains "
+                    + "invalid mapping '" + pMapping + "' in configuration file '" + pPropertyFile + "'");
+        }
+
+        final String unsupportedVersion = kv[0];
+        final String goodVersion = kv[1];
+        if (unsupportedVersion.isEmpty() || goodVersion.isEmpty()) {
+            throw new CheckStylePluginException("Internal error: Property '" + PROP_VERSION_MAP + "' contains "
+                    + "invalid mapping '" + pMapping + "' in configuration file '" + pPropertyFile + "'");
+        }
+
+        if (!pSupportedVersions.contains(goodVersion)) {
+            throw new CheckStylePluginException("Internal error: Property '" + PROP_VERSION_MAP + "' contains "
+                    + "invalid mapping '" + pMapping + "'. Target version " + goodVersion + " is not a supported "
+                    + "version in configuration file '" + pPropertyFile + "'");
+        }
+        if (pSupportedVersions.contains(unsupportedVersion)) {
+            throw new CheckStylePluginException("Internal error: Property '" + PROP_VERSION_MAP + "' contains "
+                    + "invalid mapping '" + pMapping + "'. Checkstyle version " + unsupportedVersion + " is in "
+                    + "fact supported in configuration file '" + pPropertyFile + "'");
+        }
+        return new Pair<>(unsupportedVersion, goodVersion);
+    }
+
+
+    @NotNull
     public SortedSet<String> getSupportedVersions() {
         return supportedVersions;
     }
@@ -119,5 +188,10 @@ class VersionListReader
     @NotNull
     public static String getDefaultVersion(@NotNull final SortedSet<String> pSupportedVersions) {
         return pSupportedVersions.last();
+    }
+
+    @NotNull
+    public SortedMap<String, String> getReplacementMap() {
+        return replacementMap;
     }
 }

--- a/src/main/resources/checkstyle-idea.properties
+++ b/src/main/resources/checkstyle-idea.properties
@@ -14,8 +14,14 @@
 
 checkstyle.versions.java7 = 6.2, 6.4.1, 6.5, 6.6, 6.7, 6.8.2, 6.9, 6.10.1, 6.11.2, 6.12, 6.12.1, 6.13, 6.14.1, 6.15, \
     6.16.1, 6.19
-checkstyle.versions.java8 = 7.1, 7.1.1, 7.1.2, 7.2, 7.3, 7.4, 7.5, 7.5.1, 7.6, 7.6.1, 7.7, 7.8.1, 8.0, 8.1
+checkstyle.versions.java8 = 7.1, 7.1.1, 7.1.2, 7.2, 7.3, 7.4, 7.5.1, 7.6, 7.6.1, 7.8.2, 8.0, 8.1
 
 # The "base version" must be one of the versions listed above. The sources are compiled against this version, so it is
 # the dependency shown in the IDE and the runtime used when unit tests are run from the IDE or via 'runCsaccessTests'.
 baseVersion = 7.1.1
+
+# Maps unsupported Checkstyle versions onto their supported alternative versions. If one of the keys in this map is
+# found in the plugin configuration the value in this map is used instead. A mapping is valid only if both check
+# behavior and API are compatible: http://checkstyle-addons.thomasjensen.com/checkstyle-compatibility-matrix.html
+checkstyle.versions.map = 6.8 -> 6.8.2, 6.8.1 -> 6.8.2, 6.11 -> 6.11.2, 6.11.1 -> 6.11.2, 6.14 -> 6.14.1, \
+    6.17 -> 6.19, 6.18 -> 6.19, 7.0 -> 7.1, 7.5 -> 7.5.1, 7.7 -> 7.8.2, 7.8 -> 7.8.2, 7.8.1 -> 7.8.2

--- a/src/test/java/org/infernus/idea/checkstyle/VersionListReaderTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/VersionListReaderTest.java
@@ -1,0 +1,63 @@
+package org.infernus.idea.checkstyle;
+
+
+import org.infernus.idea.checkstyle.exception.CheckStylePluginException;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class VersionListReaderTest
+{
+    @Test
+    public void testNormalLoading() {
+        VersionListReader underTest = new VersionListReader();
+        Assert.assertNotNull(underTest.getSupportedVersions());
+        Assert.assertTrue(underTest.getSupportedVersions().size() > 1);
+        Assert.assertNotNull(underTest.getDefaultVersion());
+        Assert.assertNotNull(underTest.getReplacementMap());
+        Assert.assertTrue(underTest.getReplacementMap().size() > 1);
+    }
+
+
+    @Test
+    public void testNonExistingFile() {
+        try {
+            new VersionListReader("non-existent.file");
+            Assert.fail("expected exception was not thrown");
+        }
+        catch (CheckStylePluginException e) {
+            // expected
+            Assert.assertTrue(e.getMessage().startsWith("Internal error: Could not read internal configuration file"));
+        }
+    }
+
+
+    @Test
+    public void testSupportedVersionMustNotBeMapped() {
+        try {
+            new VersionListReader("checkstyle-idea.broken1.properties");
+            Assert.fail("expected exception was not thrown");
+        }
+        catch (CheckStylePluginException e) {
+            // expected
+            Assert.assertEquals("Internal error: Property 'checkstyle.versions.map' contains "
+                    + "invalid mapping '7.1 -> 7.2'. Checkstyle version 7.1 is in fact supported "
+                    + "in configuration file 'checkstyle-idea.broken1.properties'", e.getMessage());
+        }
+    }
+
+
+    @Test
+    public void testTargetVersionMustExist() {
+        try {
+            new VersionListReader("checkstyle-idea.broken2.properties");
+            Assert.fail("expected exception was not thrown");
+        }
+        catch (CheckStylePluginException e) {
+            // expected
+            Assert.assertEquals("Internal error: Property 'checkstyle.versions.map' contains "
+                    + "invalid mapping '7.0 -> 7.1.1'. Target version 7.1.1 is not a supported "
+                    + "version in configuration file 'checkstyle-idea.broken2.properties'", e.getMessage());
+        }
+    }
+}

--- a/src/test/resources/checkstyle-idea.broken1.properties
+++ b/src/test/resources/checkstyle-idea.broken1.properties
@@ -1,0 +1,9 @@
+# Broken Checkstyle-IDEA plugin configuration for unit tests
+
+
+checkstyle.versions.java7 = 6.2, 6.3, 6.4
+checkstyle.versions.java8 = 7.1, 7.2, 7.3
+baseVersion = 7.1
+
+# Error: 7.1 is in fact supported
+checkstyle.versions.map = 7.0 -> 7.1, 7.1 -> 7.2

--- a/src/test/resources/checkstyle-idea.broken2.properties
+++ b/src/test/resources/checkstyle-idea.broken2.properties
@@ -1,0 +1,9 @@
+# Broken Checkstyle-IDEA plugin configuration for unit tests
+
+
+checkstyle.versions.java7 = 6.2, 6.3, 6.4
+checkstyle.versions.java8 = 7.1, 7.2, 7.3
+baseVersion = 7.1
+
+# Error: 7.1.1 does not exist
+checkstyle.versions.map = 7.0 -> 7.1.1


### PR DESCRIPTION
This is a little PR which improves our management capabilities of supported Checkstyle versions.
We simply introduce a map in our internal *checkstyle-idea.properties* which maps the Checkstyle versions which we don't support (i.e. bundle) to ones that we do.
In this way, we may discontinue bundling certain versions of Checkstyle when it turns out that a better compatible version exists. I already used this new ability in this PR to discontinue 7.5 (replaced by 7.5.1), 7.7, and 7.8.1 (both replaced by 7.8.2).
But this feature must be used with caution: In order to prevent configuration files or custom checks from suddenly malfunctioning, the mapped version must be fully compatible (columns C and D in [this chart](http://checkstyle-addons.thomasjensen.com/checkstyle-compatibility-matrix.html)).