### PR TITLE
Added Checkstyle 8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ CheckStyle-IDEA.zip
 gradle-app.setting
 /.gradletasknamecache
 _support/
+out/

--- a/src/main/resources/checkstyle-idea.properties
+++ b/src/main/resources/checkstyle-idea.properties
@@ -14,7 +14,7 @@
 
 checkstyle.versions.java7 = 6.2, 6.4.1, 6.5, 6.6, 6.7, 6.8.2, 6.9, 6.10.1, 6.11.2, 6.12, 6.12.1, 6.13, 6.14.1, 6.15, \
     6.16.1, 6.19
-checkstyle.versions.java8 = 7.1, 7.1.1, 7.1.2, 7.2, 7.3, 7.4, 7.5.1, 7.6, 7.6.1, 7.8.2, 8.0, 8.1
+checkstyle.versions.java8 = 7.1, 7.1.1, 7.1.2, 7.2, 7.3, 7.4, 7.5.1, 7.6, 7.6.1, 7.8.2, 8.0, 8.1, 8.2
 
 # The "base version" must be one of the versions listed above. The sources are compiled against this version, so it is
 # the dependency shown in the IDE and the runtime used when unit tests are run from the IDE or via 'runCsaccessTests'.


### PR DESCRIPTION
Hello,

[checkstyle 8.2](http://checkstyle.sourceforge.net/releasenotes.html#Release_8.2) was released yesterday and contained a bugfix (4856) which I was eagerly waiting for since it this NPE occurred with some of our projects ;).

I looked at your last commit when you added 8.1 and figured that my little change is all thats needed. I assume that bumping the version etc is done by you, or shall I provide these updates too? It would be release 5.10.0?!