### PR TITLE
Updated CustomOrderImporter to import formatter settings (#362)

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/importer/modules/CustomImportOrderImporter.java
+++ b/src/main/java/org/infernus/idea/checkstyle/importer/modules/CustomImportOrderImporter.java
@@ -1,12 +1,15 @@
 package org.infernus.idea.checkstyle.importer.modules;
 
 import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.PackageEntry;
+import com.intellij.psi.codeStyle.PackageEntryTable;
+import java.util.ArrayList;
+import java.util.function.Consumer;
 import org.infernus.idea.checkstyle.importer.ModuleImporter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("unused")
@@ -17,14 +20,26 @@ public class CustomImportOrderImporter extends ModuleImporter {
     private static final String SPECIAL_IMPORTS_REG_EXP_PROP = "specialImportsRegExp";
     private static final String SEPARATE_LINE_BETWEEN_GROUPS_PROP = "separateLineBetweenGroups";
     private static final String SORT_IMPORTS_IN_GROUP_ALPHABETICALLY_PROP = "sortImportsInGroupAlphabetically";
+    private static final String IMPORT_GROUP_SEPARATOR = "###";
 
     private List<ImportGroup> customImportOrder;
     private boolean separateLineBetweenGroups;
     private boolean sortImportsInGroupAlphabetically;
-    private Pattern standardPackageRegExp;
-    private Pattern thirdPartyPackageRegExp;
-    private Pattern specialImportsRegExp;
+    private List<String> standardPackageRegExp;
+    private List<String> thirdPartyPackageRegExp;
+    private List<String> specialImportsRegExp;
 
+    public CustomImportOrderImporter() {
+        standardPackageRegExp = new ArrayList<>();
+        standardPackageRegExp.add("javax");
+        standardPackageRegExp.add("java");
+
+        thirdPartyPackageRegExp = new ArrayList<>();
+        thirdPartyPackageRegExp.add("");
+
+        specialImportsRegExp = new ArrayList<>();
+        specialImportsRegExp.add("");
+    }
 
     @Override
     protected void handleAttribute(@NotNull String attrName, @NotNull String attrValue) {
@@ -33,13 +48,13 @@ public class CustomImportOrderImporter extends ModuleImporter {
                 parseImportOrderRules(attrValue);
                 break;
             case STANDARD_PACKAGE_REG_EXP_PROP:
-                standardPackageRegExp = Pattern.compile(attrValue);
+                standardPackageRegExp = parseCustomPackagesRegExp(attrValue);
                 break;
             case THIRD_PARTY_PACKAGE_REG_EXP_PROP:
-                thirdPartyPackageRegExp = Pattern.compile(attrValue);
+                thirdPartyPackageRegExp = parseCustomPackagesRegExp(attrValue);
                 break;
             case SPECIAL_IMPORTS_REG_EXP_PROP:
-                specialImportsRegExp = Pattern.compile(attrValue);
+                specialImportsRegExp = parseCustomPackagesRegExp(attrValue);
                 break;
             case SEPARATE_LINE_BETWEEN_GROUPS_PROP:
                 separateLineBetweenGroups = Boolean.parseBoolean(attrValue);
@@ -55,18 +70,70 @@ public class CustomImportOrderImporter extends ModuleImporter {
 
     @Override
     public void importTo(@NotNull CodeStyleSettings settings) {
-        return;
+        PackageEntryTable customImportTable = createCustomImportTable();
+        settings.IMPORT_LAYOUT_TABLE.copyFrom(customImportTable);
+    }
+
+    private PackageEntryTable createCustomImportTable() {
+        PackageEntryTable table = new PackageEntryTable();
+        Consumer<String> createPackageEntry = p -> table.addEntry(new PackageEntry(false, p, true));
+
+        for(ImportGroup group : customImportOrder) {
+            switch(group) {
+                case STATIC:
+                    table.addEntry(PackageEntry.ALL_OTHER_STATIC_IMPORTS_ENTRY);
+                    break;
+                case THIRD_PARTY_PACKAGE:
+                    thirdPartyPackageRegExp.forEach(createPackageEntry);
+                    break;
+                case SPECIAL_IMPORTS:
+                    specialImportsRegExp.forEach(createPackageEntry);
+                    break;
+                case STANDARD_JAVA_PACKAGE:
+                    standardPackageRegExp.forEach(createPackageEntry);
+                    break;
+                default:
+                    // IntelliJ does not support this option or group does not exist
+                    break;
+            }
+
+            addBlankLineBetweenGroups(table);
+        }
+        table.addEntry(PackageEntry.ALL_OTHER_IMPORTS_ENTRY);
+        return table;
+    }
+
+    private void addBlankLineBetweenGroups(PackageEntryTable table) {
+        if(!separateLineBetweenGroups) {
+          return;
+        }
+
+        table.addEntry(PackageEntry.BLANK_LINE_ENTRY);
+    }
+
+    private List<String> parseCustomPackagesRegExp(@NotNull String value) {
+        String[] tokensToReplace = {"^", "$", ".*", "(", ")"};
+        for(String token : tokensToReplace) {
+            value = value.replace(token, "");
+        }
+
+        // The ending \. used in the regex value is not required in IntelliJ
+        value = value.endsWith("\\.") ? value.substring(0, value.length() - 2) : value;
+
+        String[] customPackages = value.split("\\|");
+
+        return Arrays.asList(customPackages);
     }
 
     private void parseImportOrderRules(@NotNull String value) {
-        String[] groups = value.split(value);
+        String[] groups = value.split(IMPORT_GROUP_SEPARATOR);
         customImportOrder = Arrays.stream(groups).map(ImportGroup::valueOf).collect(Collectors.toList());
     }
 
     public enum ImportGroup {
         STATIC,
         SAME_PACKAGE,
-        THIRD_PARTY,
+        THIRD_PARTY_PACKAGE,
         STANDARD_JAVA_PACKAGE,
         SPECIAL_IMPORTS
     }


### PR DESCRIPTION
This PR resumes the work started by @mqzry to import settings from the CustomImportOrder module into the IntelliJ formatter. (Issue #362)

**Notes:**
- IntelliJ does not have the option to allow us to specifically set _sortImportsAlphabetically_
- IntelliJ does not support the SAME_PACKAGE import group