### PR TITLE
Expose the internal classloader in CheckStyleProjectService

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/CheckstyleClassLoader.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckstyleClassLoader.java
@@ -251,4 +251,8 @@ public class CheckstyleClassLoader {
             throw new CheckStylePluginException("internal error", e);
         }
     }
+
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
 }

--- a/src/main/java/org/infernus/idea/checkstyle/CheckstyleProjectService.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckstyleProjectService.java
@@ -104,4 +104,20 @@ public class CheckstyleProjectService {
             throw new CheckStylePluginException("internal error", e);
         }
     }
+
+    public ClassLoader getUnderlyingClassLoader() {
+        try {
+            synchronized (project) {
+                if (checkstyleClassLoader == null) {
+                    checkstyleClassLoader = checkstyleClassLoaderFactory.call();
+                }
+                // Don't worry about caching, class loaders do lots of caching.
+                return checkstyleClassLoader.getClassLoader();
+            }
+        } catch (CheckStylePluginException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CheckStylePluginException("internal error", e);
+        }
+    }
 }

--- a/src/test/java/org/infernus/idea/checkstyle/CheckStyleClassLoaderTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/CheckStyleClassLoaderTest.java
@@ -1,0 +1,40 @@
+package org.infernus.idea.checkstyle;
+
+import com.intellij.openapi.project.Project;
+import org.infernus.idea.checkstyle.config.PluginConfiguration;
+import org.infernus.idea.checkstyle.config.PluginConfigurationBuilder;
+import org.infernus.idea.checkstyle.config.PluginConfigurationManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CheckStyleClassLoaderTest {
+
+    private static final String CHECKSTYLE_VERSION = "7.1.1";
+
+    private static final Project PROJECT = mock(Project.class);
+
+    private CheckstyleProjectService underTest;
+
+    @Before
+    public void setUp() {
+        PluginConfigurationManager mockPluginConfig = mock(PluginConfigurationManager.class);
+        final PluginConfiguration mockConfigDto = PluginConfigurationBuilder.testInstance(CHECKSTYLE_VERSION).build();
+        when(mockPluginConfig.getCurrent()).thenReturn(mockConfigDto);
+        underTest = new CheckstyleProjectService(PROJECT, mockPluginConfig);
+        underTest.activateCheckstyleVersion(CHECKSTYLE_VERSION, null);
+    }
+
+    @Test
+    public void testCanLoadClassLoader() {
+        assertNotNull(underTest.getUnderlyingClassLoader());
+    }
+
+    @Test
+    public void classLoaderCanLoadCheckStyleInternalClasses() throws ClassNotFoundException {
+        assertNotNull(underTest.getUnderlyingClassLoader().loadClass("com.puppycrawl.tools.checkstyle.Checker"));
+    }
+}


### PR DESCRIPTION
I am working on a plugin that depends on the CheckStyle IDEA plugin and I needed to get some classes from CheckStyle. It appeared that this plugin does dynamic loading of the CheckStyle versions. While this works, I required to get hold on the actual created `ClassLoader` to get the classes.

Without this method, I was forced to implement the current behavior with Reflection:

```java
private ClassLoader getPluginCreatedClassLoaderFromService(CheckstyleProjectService service) throws NoSuchFieldException, IllegalAccessException {
  Field checkstyleClassLoaderField = service.getClass().getDeclaredField("checkstyleClassLoader");
  checkstyleClassLoaderField.setAccessible(true);


  CheckstyleClassLoader loader = ((CheckstyleClassLoader) checkstyleClassLoaderField.get(service));


  Field classLoaderField = loader.getClass().getDeclaredField("classLoader");
  classLoaderField.setAccessible(true);


  return (ClassLoader) classLoaderField.get(loader);
}
```

It would be great to have a type-safe manner to get hold of the generated `ClassLoader`.

I have added a simple test that obtains the created classLoader and verifies it can load the `Checker` class from the CheckStyle jar.