### PR TITLE
Some minor changes for supported versions of Checkstyle

### DIFF
--- a/src/main/resources/checkstyle-idea.properties
+++ b/src/main/resources/checkstyle-idea.properties
@@ -7,8 +7,8 @@
 
 checkstyle.versions.java7 = 6.2, 6.4.1, 6.5, 6.6, 6.7, 6.8.2, 6.9, 6.10.1, 6.11.2, 6.12.1, 6.13, 6.14.1, 6.15, \
     6.16.1, 6.19
-checkstyle.versions.java8 = 7.1.2, 7.2, 7.3, 7.4, 7.5.1, 7.6.1, 7.8.2, \
-    8.0, 8.1, 8.2, 8.3, 8.5, 8.6, 8.7, 8.8, 8.9, 8.10.1, 8.14, 8.16
+checkstyle.versions.java8 = 7.1.2, 7.2, 7.3, 7.4, 7.5.1, 7.6, 7.6.1, 7.8.2, \
+    8.0, 8.1, 8.2, 8.3, 8.5, 8.6, 8.7, 8.8, 8.10.1, 8.14, 8.16
 
 # The "base version" must be one of the versions listed above. The sources are compiled against this version, so it is
 # the dependency shown in the IDE and the runtime used when unit tests are run from the IDE or via 'runCsaccessTests'.
@@ -16,15 +16,15 @@ baseVersion = 7.1.2
 
 # Maps unsupported Checkstyle versions onto their supported alternative versions. If one of the keys in this map is
 # found in the plugin configuration the value in this map is used instead. A mapping is valid only if both check
-# behavior and API are compatible: http://checkstyle-addons.thomasjensen.com/checkstyle-compatibility-matrix.html
+# behavior and API are compatible: https://checkstyle-addons.thomasjensen.com/checkstyle-compatibility-matrix.html
 checkstyle.versions.map = 6.8 -> 6.8.2, 6.8.1 -> 6.8.2, \
     6.11 -> 6.11.2, 6.11.1 -> 6.11.2, \
     6.12 -> 6.12.1, \
     6.14 -> 6.14.1, 6.17 -> 6.19, 6.18 -> 6.19, \
     7.0 -> 7.1.2, 7.1 -> 7.1.2, 7.1.1 -> 7.1.2, \
     7.5 -> 7.5.1, \
-    7.6 -> 7.6.1, \
     7.7 -> 7.8.2, 7.8 -> 7.8.2, 7.8.1 -> 7.8.2, \
     8.4 -> 8.5, \
-    8.10 -> 8.10.1, \
-    8.11 -> 8.14, 8.12 -> 8.14, 8.13 -> 8.14
+    8.9 -> 8.10.1, 8.10 -> 8.10.1, \
+    8.11 -> 8.14, 8.12 -> 8.14, 8.13 -> 8.14, \
+    8.15 -> 8.16


### PR DESCRIPTION
Hi, I just noticed some major cleanup of the supported versions, and as you might expect, and I can't let the opportunity pass by without giving some comments.

TL/DR: We should make the changes in this PR. 😉 

Long version:
- 6.12 → 6.12.1: probably ok, as people only see some warnings disappear
- 7.1, 7.1.1 → 7.1.2: probably ok too, as they tried to fix the equals/hashCode behavior. But that behavior *does* differ between versions.
- 7.6 → 7.6.1: I actually added back 7.6, because it threw different exceptions from the API, and this breaks custom checks
- 8.4 → 8.5: ✔
- 8.11, 8.12, 8.13 → 8.14: ✔
- I added 8.9 → 8.10.1
- plus, I added a mapping for 8.15 → 8.16, as these versions appear to be compatible, and 8.15 was missing so far.

Hope this helps!