### PR TITLE
Fix for #432 (white background showing through when using Darcula theme)

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/toolwindow/CheckStyleToolWindowPanel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/toolwindow/CheckStyleToolWindowPanel.java
@@ -184,7 +184,7 @@ public class CheckStyleToolWindowPanel extends JPanel implements ConfigurationLi
         progressPanel.add(progressLabel);
         progressPanel.add(Box.createHorizontalGlue());
         progressPanel.setFloatable(false);
-        progressPanel.setBackground(UIManager.getColor("Panel.background"));
+        progressPanel.setOpaque(false);
         progressPanel.setBorder(null);
 
         final JPanel toolPanel = new JPanel(new BorderLayout());


### PR DESCRIPTION
Made the progress panel (JToolBar)  transparent so it will use the parent panel background

Tested on 2018.3.5, 2019.1 EAP and 2016.1