### PR TITLE
Fix: Don't request resources from classloader with leading slash

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/model/ConfigurationLocation.java
+++ b/src/main/java/org/infernus/idea/checkstyle/model/ConfigurationLocation.java
@@ -254,8 +254,7 @@ public abstract class ConfigurationLocation implements Cloneable, Comparable<Con
 
     private boolean existsOnClasspath(final String fileName,
                                      final ClassLoader checkstyleClassLoader) {
-        return checkstyleClassLoader.getResource(fileName) != null
-                || (fileName.startsWith("/") && checkstyleClassLoader.getResource(fileName.substring(1)) != null);
+        return checkstyleClassLoader.getResource(fileName.startsWith("/") ? fileName.substring(1) : fileName) != null;
     }
 
     private File checkCommonPathsForTarget(final String fileName,


### PR DESCRIPTION
Sinec intellij 2021 PluginClassLoader started complaining about requesting resources with leading slash https://github.com/JetBrains/intellij-community/blob/master/platform/core-impl/src/com/intellij/ide/plugins/cl/PluginClassLoader.java#L470. Even though it complains it's only a log and classloader will strip the leading slash and move on. In order to avoid unnecessary error logs on every project open existOnClasspath will always request resourec for existence check without leading slash