### PR TITLE
save all modified files before running the checks or reloading the configuration

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/actions/ResetLoadedRulesFiles.java
+++ b/src/main/java/org/infernus/idea/checkstyle/actions/ResetLoadedRulesFiles.java
@@ -1,6 +1,9 @@
 package org.infernus.idea.checkstyle.actions;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import org.infernus.idea.checkstyle.config.PluginConfigurationManager;
 import org.infernus.idea.checkstyle.checker.CheckerFactoryCache;
 import org.infernus.idea.checkstyle.model.ConfigurationLocation;
@@ -15,6 +18,16 @@ public class ResetLoadedRulesFiles extends BaseAction {
 
     @Override
     public void actionPerformed(@NotNull final AnActionEvent event) {
+        if (FileDocumentManager.getInstance().getUnsavedDocuments().length > 0) {
+            // If there is an unsaved file, this could be the changed rules file or a dependent file.
+            // Save them first, then continue.
+            ApplicationManager.getApplication().runWriteAction(() -> {
+                for (Document unsavedDocument : FileDocumentManager.getInstance().getUnsavedDocuments()) {
+                    FileDocumentManager.getInstance().saveDocument(unsavedDocument);
+                }
+            });
+        }
+
         project(event).ifPresent(project -> {
             getService(project, PluginConfigurationManager.class)
                     .getCurrent()


### PR DESCRIPTION
This might fix #459.

I noticed the problem that the configuration wasn't reloaded even after clicking the button. This now saves all modified files to disk first, and then runs the check. 