### PR TITLE
enable checkstyle in the dumb mode; that is when indexing is still running.

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/actions/BaseAction.java
+++ b/src/main/java/org/infernus/idea/checkstyle/actions/BaseAction.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindow;
@@ -25,7 +26,7 @@ import static org.infernus.idea.checkstyle.actions.ToolWindowAccess.getFromToolW
 /**
  * Base class for plug-in actions.
  */
-public abstract class BaseAction extends AnAction {
+public abstract class BaseAction extends DumbAwareAction {
 
     private static final Logger LOG = Logger.getInstance(BaseAction.class);
 

--- a/src/main/java/org/infernus/idea/checkstyle/actions/DisplayErrors.java
+++ b/src/main/java/org/infernus/idea/checkstyle/actions/DisplayErrors.java
@@ -1,7 +1,7 @@
 package org.infernus.idea.checkstyle.actions;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.ToggleAction;
+import com.intellij.openapi.project.DumbAwareToggleAction;
 import com.intellij.openapi.project.Project;
 import org.infernus.idea.checkstyle.toolwindow.CheckStyleToolWindowPanel;
 
@@ -10,7 +10,7 @@ import static org.infernus.idea.checkstyle.actions.ToolWindowAccess.*;
 /**
  * Action to toggle error display in tool window.
  */
-public class DisplayErrors extends ToggleAction {
+public class DisplayErrors extends DumbAwareToggleAction {
 
     @Override
     public boolean isSelected(final AnActionEvent event) {

--- a/src/main/java/org/infernus/idea/checkstyle/actions/DisplayInfo.java
+++ b/src/main/java/org/infernus/idea/checkstyle/actions/DisplayInfo.java
@@ -1,7 +1,7 @@
 package org.infernus.idea.checkstyle.actions;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.ToggleAction;
+import com.intellij.openapi.project.DumbAwareToggleAction;
 import com.intellij.openapi.project.Project;
 import org.infernus.idea.checkstyle.toolwindow.CheckStyleToolWindowPanel;
 
@@ -10,7 +10,7 @@ import static org.infernus.idea.checkstyle.actions.ToolWindowAccess.*;
 /**
  * Action to toggle error display in tool window.
  */
-public class DisplayInfo extends ToggleAction {
+public class DisplayInfo extends DumbAwareToggleAction {
 
     @Override
     public boolean isSelected(final AnActionEvent event) {

--- a/src/main/java/org/infernus/idea/checkstyle/actions/DisplayWarnings.java
+++ b/src/main/java/org/infernus/idea/checkstyle/actions/DisplayWarnings.java
@@ -1,7 +1,7 @@
 package org.infernus.idea.checkstyle.actions;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.ToggleAction;
+import com.intellij.openapi.project.DumbAwareToggleAction;
 import com.intellij.openapi.project.Project;
 import org.infernus.idea.checkstyle.toolwindow.CheckStyleToolWindowPanel;
 
@@ -10,7 +10,7 @@ import static org.infernus.idea.checkstyle.actions.ToolWindowAccess.*;
 /**
  * Action to toggle error display in tool window.
  */
-public class DisplayWarnings extends ToggleAction {
+public class DisplayWarnings extends DumbAwareToggleAction {
 
     @Override
     public boolean isSelected(final AnActionEvent event) {

--- a/src/main/java/org/infernus/idea/checkstyle/actions/ScrollToSource.java
+++ b/src/main/java/org/infernus/idea/checkstyle/actions/ScrollToSource.java
@@ -1,7 +1,7 @@
 package org.infernus.idea.checkstyle.actions;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.ToggleAction;
+import com.intellij.openapi.project.DumbAwareToggleAction;
 import com.intellij.openapi.project.Project;
 import org.infernus.idea.checkstyle.toolwindow.CheckStyleToolWindowPanel;
 
@@ -10,7 +10,7 @@ import static org.infernus.idea.checkstyle.actions.ToolWindowAccess.*;
 /**
  * Toggle the scroll to source setting.
  */
-public final class ScrollToSource extends ToggleAction {
+public final class ScrollToSource extends DumbAwareToggleAction {
 
     @Override
     public boolean isSelected(final AnActionEvent event) {

--- a/src/main/java/org/infernus/idea/checkstyle/toolwindow/CheckStyleToolWindowFactory.java
+++ b/src/main/java/org/infernus/idea/checkstyle/toolwindow/CheckStyleToolWindowFactory.java
@@ -1,5 +1,6 @@
 package org.infernus.idea.checkstyle.toolwindow;
 
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
@@ -8,7 +9,7 @@ import com.intellij.ui.content.Content;
 import org.infernus.idea.checkstyle.CheckStyleBundle;
 import org.jetbrains.annotations.NotNull;
 
-public class CheckStyleToolWindowFactory implements ToolWindowFactory {
+public class CheckStyleToolWindowFactory implements ToolWindowFactory, DumbAware {
 
     @Override
     public void createToolWindowContent(@NotNull final Project project, @NotNull final ToolWindow toolWindow) {

--- a/src/main/java/org/infernus/idea/checkstyle/toolwindow/CheckStyleToolWindowPanel.java
+++ b/src/main/java/org/infernus/idea/checkstyle/toolwindow/CheckStyleToolWindowPanel.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.editor.ScrollType;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.TextEditor;
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -53,7 +54,7 @@ import static org.infernus.idea.checkstyle.util.Strings.isBlank;
 /**
  * The tool window for CheckStyle scans.
  */
-public class CheckStyleToolWindowPanel extends JPanel implements ConfigurationListener {
+public class CheckStyleToolWindowPanel extends JPanel implements ConfigurationListener, DumbAware {
 
     public static final String ID_TOOLWINDOW = "CheckStyle";
 


### PR DESCRIPTION
I noticed that tool window is not available while the indexing of the IDE is still happening. 

I had a look at the source and didn't find at first glance a reason why this should be the case. Please correct me if I'm wrong here. 

Now, as an impatient user, I can run CheckStyle even when indexing is still underway.