### PR TITLE
re add version 10.3.1 to the list of supported versions

### DIFF
--- a/src/main/resources/checkstyle-idea.properties
+++ b/src/main/resources/checkstyle-idea.properties
@@ -6,7 +6,7 @@ checkstyle.versions.supported = \
     8.34, 8.35, 8.36.2, 8.37, 8.38, 8.39, 8.40, 8.41.1, 8.42, 8.43, 8.44,   \
     8.45.1, \
     9.0.1, 9.1, 9.2.1, 9.3, \
-    10.0, 10.1, 10.2, 10.3.2
+    10.0, 10.1, 10.2, 10.3.1, 10.3.2
 
 # The "base version" must be one of the versions listed above. The sources are compiled against this version, so it is
 # the dependency shown in the IDE and the runtime used when unit tests are run from the IDE or via 'runCsaccessTests'.


### PR DESCRIPTION
At Codacy the version 10.3.1 is the current used version.
(see https://docs.codacy.com/release-notes/cloud/cloud-2022-07/)
Therefore it make sense to re add this version to the list of supported versions.