### PR TITLE
Major Fix: Don't set thread context classloader in CheckerWorkerFactory

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/checker/CheckerFactoryWorker.java
+++ b/src/main/java/org/infernus/idea/checkstyle/checker/CheckerFactoryWorker.java
@@ -34,8 +34,6 @@ class CheckerFactoryWorker extends Thread {
     public void run() {
         super.run();
 
-        setContextClassLoader(loaderOfCheckedCode);
-
         try {
             final CheckStyleChecker checker = checkstyleProjectService
                     .getCheckstyleInstance()


### PR DESCRIPTION
Setting this causes problems and is also a security issue.

The TCCL is generally inappropriate to set since it indicates to all classes that they should load services etc from this classloader, which in this case means loading services from the *user's project classpath* within an IDEA plugin, something which should clearly never be done.

In the worst case this allows a malicious dependency to execute completely arbitrary code within my IDEA instance (with full access to IDEA's apis) simply by being on my classpath.

In my particular case, one of my dependencies has a custom `org.apache.logging.log4j.spi.Provider` which gets loaded by the logging within checkstyle from this plugin, and then takes over the logging for all of IDEA.

The root cause is the same as #555, but the approach of filtering resources feels like a bandaid unless there is a particular reason we need to set the context classloader at all. The plugin works fine after this change in my testing.

If there is indeed as I suspect no reason to set the context classloader, then ResourceFilteringURLClassLoader can be removed entirely, just wanted to confirm this before doing it.

Perhaps there is no reason to make a classloader with the user's deps at all since it seems otherwise unused in newer checkstyle versions.