### PR TITLE
Expose extension point for custom Checkstyle quick fixes

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/checker/CheckstyleQuickFixProvider.java
+++ b/src/main/java/org/infernus/idea/checkstyle/checker/CheckstyleQuickFixProvider.java
@@ -1,0 +1,33 @@
+package org.infernus.idea.checkstyle.checker;
+
+import com.intellij.codeInspection.LocalQuickFix;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Interface for providing quick fixes for Checkstyle problems.
+ * <p>This interface allows plugins or extensions to register custom quick fixes that can be applied to Checkstyle violations.
+ * Implementations should return an array of {@code LocalQuickFix} objects that represent the available fixes for a given problem.
+ * The {@code getQuickFixes} method is called by the Checkstyle inspection engine when a problem is detected.
+ *
+ * @author dong4j
+ * @version 1.0.0
+ * @email "mailto:dong4j@gmail.com"
+ * @date 2026.01.20
+ * @since 26.0.0
+ */
+public interface CheckstyleQuickFixProvider {
+
+    /**
+     * Provides additional quick fixes for a given Checkstyle problem.
+     * <p>Implementations should return an array of {@code LocalQuickFix} objects that offer
+     * applicable fixes for the specified {@code Problem}. The return value may be {@code null}
+     * if no quick fixes are available for the problem.
+     *
+     * @param problem the Checkstyle problem for which quick fixes are requested; must not be null
+     * @return an array of quick fixes, which may be null if none are applicable
+     */
+    @Nullable
+    LocalQuickFix[] getQuickFixes(@NotNull Problem problem);
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -53,6 +53,13 @@
         ]]>
     </change-notes>
 
+    <extensionPoints>
+        <extensionPoint name="checkstyleQuickFixProvider"
+                        interface="org.infernus.idea.checkstyle.checker.CheckstyleQuickFixProvider"
+                        dynamic="true"
+                        area="IDEA_PROJECT"/>
+    </extensionPoints>
+
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="org.infernus.idea.checkstyle.StaticScanner"/>
         <projectService serviceImplementation="org.infernus.idea.checkstyle.checker.CheckerFactoryCache"/>


### PR DESCRIPTION
### Background

Checkstyle-IDEA currently provides a limited, built-in set of quick fixes (such as suppressions).
While this works for common cases, it makes it difficult for external plugins to contribute
more advanced or domain-specific quick fixes without modifying core code.

This limitation becomes more apparent when integrating intelligent or automated fix strategies
(e.g. AI-assisted fixes, project-specific conventions, or organization-level rules).

---

### What’s in this PR

This PR introduces a public extension point that allows third-party plugins to contribute
custom quick fixes for Checkstyle problems.

Specifically, it:

- Defines a `CheckstyleQuickFixProvider` interface for supplying additional quick fixes
- Exposes a corresponding extension point in `plugin.xml`
- Aggregates quick fixes from both built-in logic and registered extension providers
- Preserves existing behavior for users who do not install any extensions

---

### Why this change

- Keeps core Checkstyle-IDEA logic simple and stable
- Enables extensibility without requiring forks or patches
- Allows advanced quick fix strategies to evolve independently of the core plugin
- Provides a foundation for future integrations such as AI-based or rule-specific fixes

---

### Compatibility and impact

- Fully backward-compatible
- No behavior changes unless a plugin explicitly registers the new extension point
- No impact on existing quick fix or suppression workflows

---

### Follow-up possibilities

- External plugins providing AI-assisted or heuristic-based quick fixes
- Project- or organization-specific Checkstyle rule fixes
- Gradual enrichment of the quick fix ecosystem without increasing core complexity