### PR TITLE
Fix third-party classpath for downloaded Checkstyle

### DIFF
--- a/src/main/java/org/infernus/idea/checkstyle/CheckstyleClassLoaderContainer.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckstyleClassLoaderContainer.java
@@ -77,19 +77,28 @@ public class CheckstyleClassLoaderContainer {
     public CheckstyleClassLoaderContainer(@NotNull final Project project,
                                           @NotNull final CheckstyleProjectService checkstyleProjectService,
                                           @NotNull final List<Path> downloadedJars) {
+        this(project, checkstyleProjectService, downloadedJars, null);
+    }
+
+    public CheckstyleClassLoaderContainer(@NotNull final Project project,
+                                          @NotNull final CheckstyleProjectService checkstyleProjectService,
+                                          @NotNull final List<Path> downloadedJars,
+                                          @Nullable final List<URL> thirdPartyClassPath) {
         this.project = project;
         this.checkstyleProjectService = checkstyleProjectService;
-        classLoader = buildClassLoaderFromPaths(downloadedJars);
+        classLoader = buildClassLoaderFromPaths(downloadedJars, emptyListIfNull(thirdPartyClassPath));
     }
 
     @NotNull
-    private ClassLoader buildClassLoaderFromPaths(@NotNull final List<Path> jars) {
+    private ClassLoader buildClassLoaderFromPaths(@NotNull final List<Path> jars,
+                                                  @NotNull final List<URL> thirdPartyClasspath) {
         try {
             final List<URL> urls = new ArrayList<>();
             urls.add(getCsaccessClassesUrl());
             for (final Path jar : jars) {
                 urls.add(jar.toUri().toURL());
             }
+            urls.addAll(thirdPartyClasspath);
             return new ChildFirstURLClassLoader(urls.toArray(new URL[0]), getClass().getClassLoader());
         } catch (MalformedURLException e) {
             throw new CheckStylePluginException("Failed to build classloader from downloaded JARs", e);

--- a/src/main/java/org/infernus/idea/checkstyle/CheckstyleProjectService.java
+++ b/src/main/java/org/infernus/idea/checkstyle/CheckstyleProjectService.java
@@ -111,7 +111,8 @@ public class CheckstyleProjectService {
                         throw new CheckStylePluginException(
                                 "Checkstyle " + checkstyleVersionToLoad + " is not bundled and has not been downloaded");
                     }
-                    return new CheckstyleClassLoaderContainer(project, this, downloader.download(checkstyleVersionToLoad));
+                    return new CheckstyleClassLoaderContainer(
+                            project, this, downloader.download(checkstyleVersionToLoad), toListOfUrls(thirdPartyJars));
                 }
             };
         }

--- a/src/test/java/org/infernus/idea/checkstyle/CheckstyleProjectServiceTest.java
+++ b/src/test/java/org/infernus/idea/checkstyle/CheckstyleProjectServiceTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.net.URLClassLoader;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.SortedSet;
 
@@ -70,6 +72,24 @@ public class CheckstyleProjectServiceTest {
 
         assertNotNull(serviceWithDownloader.underlyingClassLoader());
         verify(mockDownloader).download(NON_BUNDLED_VERSION);
+    }
+
+    @Test
+    public void nonBundledVersion_addsThirdPartyClasspath(@TempDir Path tempDir) throws Exception {
+        Path fakeCheckstyleJar = tempDir.resolve("checkstyle-10.4.jar");
+        fakeCheckstyleJar.toFile().createNewFile();
+        Path thirdPartyJar = tempDir.resolve("third-party.jar");
+        thirdPartyJar.toFile().createNewFile();
+
+        CheckstyleArtifactDownloader mockDownloader = mock(CheckstyleArtifactDownloader.class);
+        when(mockDownloader.download(NON_BUNDLED_VERSION)).thenReturn(List.of(fakeCheckstyleJar));
+
+        CheckstyleProjectService serviceWithDownloader =
+                new CheckstyleProjectService(project, mockDownloader);
+        serviceWithDownloader.activateCheckstyleVersion(NON_BUNDLED_VERSION, List.of(thirdPartyJar.toString()));
+
+        URLClassLoader classLoader = (URLClassLoader) serviceWithDownloader.underlyingClassLoader();
+        assertThat(Arrays.asList(classLoader.getURLs()), hasItem(thirdPartyJar.toUri().toURL()));
     }
 
     @Test


### PR DESCRIPTION
Fixes #694.

Downloaded Checkstyle versions built their classloader only from downloaded artifacts, while bundled versions also included configured third-party classpath entries. This made custom checks unavailable for downloaded versions such as 12.1.2.

This change passes the configured third-party classpath into the downloaded-version classloader and adds a regression test covering that path.

Tested:
- ./gradlew test --tests org.infernus.idea.checkstyle.CheckstyleProjectServiceTest --no-daemon --console=plain
- ./gradlew buildPlugin --no-daemon --console=plain
- Manual plugin test with downloaded Checkstyle and third-party checks